### PR TITLE
Ocultar opção de assinatura com certificado digital

### DIFF
--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aAssinar.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aAssinar.jsp
@@ -125,7 +125,7 @@
 							
 							<c:set var="podeAssinarComSenha" value="${assinando and f:podeAssinarComSenha(titular,lotaTitular,doc.mobilGeral) }" />
 							<c:set var="podeAutenticarComSenha" value="${autenticando and f:podeAutenticarComSenha(titular,lotaTitular,doc.mobilGeral) }" />
-							<c:set var="defaultAssinarComSenha" value="${f:deveAssinarComSenha(titular,lotaTitular,doc.mobilGeral) }" />
+							<c:set var="defaultAssinarComSenha" value="true" />
 							<c:set var="defaultAutenticarComSenha" value="${f:deveAutenticarComSenha(titular,lotaTitular,doc.mobilGeral) }" />
 							
 							<c:set var="podeUtilizarSegundoFatorPin" value="${f:podeUtilizarSegundoFatorPin(cadastrante,cadastrante.lotacao)}" />

--- a/sigaex/src/main/webapp/WEB-INF/tags/assinatura_botoes.tag
+++ b/sigaex/src/main/webapp/WEB-INF/tags/assinatura_botoes.tag
@@ -76,7 +76,7 @@
 				</div>
 			</c:if>
 			
-			<c:if test="${f:podeUtilizarServicoPorConfiguracao(titular,lotaTitular,'SIGA;DOC;ASS')}">
+			<c:if test="false">
 				<div class="custom-control custom-radio">
 					<input class="custom-control-input" type="radio" 
 						accesskey="d" name="radioProviderAssinatura" id="ad_certificado_0" 


### PR DESCRIPTION
Foi decido ocultar temporariamente a opção de assinatura com certificado digital.