### PR TITLE
Configurar orgão do usuário como lotação destino ao digitar

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -838,13 +838,11 @@ public class CpDao extends ModeloDao {
 			predicates.and(siglaCompletaIniciaCom.or(siglaIniciaCom));
 		}
 
-		if (!filtro.isBuscarSemLimitarOrgaoOrigem()) {
-			if (filtro.getIdOrgaoUsu() == null) {
-				throw new AplicacaoException("Não foi possível identificar órgão do usuário requisitante.");
-			}
-
-			predicates.and(qDpLotacao.orgaoUsuario.idOrgaoUsu.eq(filtro.getIdOrgaoUsu()));
+		if (filtro.getIdOrgaoUsu() == null) {
+			throw new AplicacaoException("Não foi possível identificar órgão do usuário requisitante.");
 		}
+
+		predicates.and(qDpLotacao.orgaoUsuario.idOrgaoUsu.eq(filtro.getIdOrgaoUsu()));
 
 		return consultarLotacao(predicates);
 	}

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
@@ -162,10 +162,7 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Path({ "/public/app/lotacao/selecionar", "app/lotacao/selecionar", "/lotacao/selecionar.action" })
 	public String selecionar(final String propriedade, final String sigla) {
 		if (equalsIgnoreCase("lotacaoDestinatario", propriedade)) {
-			this.semLimiteOrgaoOrigem = getTitular().isTramitarOutrosOrgaos();
-			if (!this.semLimiteOrgaoOrigem) {
-				this.orgaoUsu = getTitular().getOrgaoUsuario().getId();
-			}
+			this.orgaoUsu = getTitular().getOrgaoUsuario().getId();
 		}
 
 		String resultado = super.aSelecionar(sigla);


### PR DESCRIPTION
Ignorar atributo `tramitar_outros_orgaos` apenas para o caso digitação (e tabulação) no campo de pesquisa.
A busca via popup (botão `...`) segue normalmente.