### PR TITLE
Correção botão ativar e inativar cadastro de pessoa

### DIFF
--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006 - 2011 SJRJ.
+* Copyright (c) 2006 - 2011 SJRJ.
  * 
  *     This file is part of SIGA.
  * 
@@ -375,8 +375,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 				pessoa.setEmailPessoa(pessoaAnt.getEmailPessoa());
 				pessoa.setIdInicial(pessoaAnt.getIdInicial());
 				try {
-					dao().gravarComHistorico(pessoa, pessoaAnt,dao().consultarDataEHoraDoServidor(), getIdentidadeCadastrante());
-					//Cp.getInstance().getBL().criarIdentidadeAposEditar(pessoa.getSesbPessoa() + pessoa.getMatricula(), pessoaAnt.getCpfFormatado(), identidadePesquisa);				
+					dao().gravarComHistorico(pessoa, pessoaAnt,dao().consultarDataEHoraDoServidor(), getIdentidadeCadastrante());				
 				} catch (Exception e) {
 					if(e.getCause() instanceof ConstraintViolationException &&
 	    					("CORPORATIVO.DP_PESSOA_UNIQUE_PESSOA_ATIVA".equalsIgnoreCase(((ConstraintViolationException)e.getCause()).getConstraintName()))) {

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
@@ -233,7 +233,8 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	}
 
 	@Get("app/pessoa/listar")
-	public void lista(Integer paramoffset, Long idOrgaoUsu, String nome, String cpfPesquisa, Long idCargoPesquisa, Long idFuncaoPesquisa, Long idLotacaoPesquisa, String emailPesquisa, String identidadePesquisa) throws Exception {
+	public void lista(Integer paramoffset, Long idOrgaoUsu, String nome, String cpfPesquisa, Long idCargoPesquisa, Long idFuncaoPesquisa, Long idLotacaoPesquisa, String emailPesquisa, String identidadePesquisa,
+			boolean buscarInativos) throws Exception {
 		
 		result.include("request",getRequest());
 		List<CpOrgaoUsuario> list = new ArrayList<CpOrgaoUsuario>();
@@ -260,6 +261,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 		if (idOrgaoUsu != null && (CpConfiguracaoBL.SIGLA_ORGAO_ROOT.equals(getTitular().getOrgaoUsuario().getSigla()) || CpConfiguracaoBL.SIGLA_ORGAO_CODATA_ROOT.equals(getTitular().getOrgaoUsuario().getSigla())
 				|| CpDao.getInstance().consultarPorSigla(getTitular().getOrgaoUsuario()).getId().equals(idOrgaoUsu))) {
 			DpPessoaDaoFiltro dpPessoa = new DpPessoaDaoFiltro();
+			dpPessoa.setBuscarFechadas(buscarInativos);
 			if (paramoffset == null) {
 				paramoffset = 0;
 			}
@@ -374,6 +376,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 				pessoa.setIdInicial(pessoaAnt.getIdInicial());
 				try {
 					dao().gravarComHistorico(pessoa, pessoaAnt,dao().consultarDataEHoraDoServidor(), getIdentidadeCadastrante());
+					//Cp.getInstance().getBL().criarIdentidadeAposEditar(pessoa.getSesbPessoa() + pessoa.getMatricula(), pessoaAnt.getCpfFormatado(), identidadePesquisa);				
 				} catch (Exception e) {
 					if(e.getCause() instanceof ConstraintViolationException &&
 	    					("CORPORATIVO.DP_PESSOA_UNIQUE_PESSOA_ATIVA".equalsIgnoreCase(((ConstraintViolationException)e.getCause()).getConstraintName()))) {
@@ -386,7 +389,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 			}
 
 			
-			this.result.redirectTo(this).lista(offset, idOrgaoUsu, nome, cpfPesquisa, idCargoPesquisa, idFuncaoPesquisa, idLotacaoPesquisa, emailPesquisa, identidadePesquisa);
+			this.result.redirectTo(this).lista(offset, idOrgaoUsu, nome, cpfPesquisa, idCargoPesquisa, idFuncaoPesquisa, idLotacaoPesquisa, emailPesquisa, identidadePesquisa, false);
 		}
 	}
 
@@ -633,7 +636,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 			result.include(SigaModal.ALERTA, e.getMessage());
 		}
 
-		lista(0, null, "", "", null, null, null, "", null);
+		lista(0, null, "", "", null, null, null, "", null, false);
 	}
 
 	

--- a/siga/src/main/webapp/WEB-INF/page/dpPessoa/lista.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpPessoa/lista.jsp
@@ -269,7 +269,8 @@
 				<c:url var="url" value="/app/pessoa/editar"></c:url>
 				<c:url var="urlAtivarInativar" value="/app/pessoa/ativarInativar"></c:url>
 				<input type="button" value="Incluir" onclick="javascript:window.location.href='${url}'" class="btn btn-primary">
-			</div>				
+			</div>
+			<input type="hidden" name="buscarInativos" value="true">				
 		</form>
 				
 		<siga:siga-modal id="confirmacaoModal" exibirRodape="false" tituloADireita="Confirma&ccedil;&atilde;o">


### PR DESCRIPTION
Correção do botão Ativar e Inativar em Cadastro de Pessoas.
Ao clicar no botão inativar usuário desaparece e não figura mais na lista de cadastrados.
Foi recolocado o botão e sua funcionalidade, bem como listar novamente o Usuário mesmo estando desativado.

Aguardo revisão dos colegas.