### PR TITLE
[Feature] ativar 'trava' para criação de novos volumes

### DIFF
--- a/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/ex/api/v1/ExApiV1Servlet.java
@@ -212,7 +212,7 @@ public class ExApiV1Servlet extends SwaggerServlet implements IPropertyProvider 
 		addPublicProperty("conversor.html.ext", "br.gov.jfrj.itextpdf.FlyingSaucer");
 		addPublicProperty("pdf.visualizador", "pdf.js");
 		addPublicProperty("conversor.html.factory", "br.gov.jfrj.siga.ex.ext.ConversorHTMLFactory");
-		addPublicProperty("data.obrigacao.assinar.anexo.despacho", "31/12/2099");
+		addPublicProperty("data.obrigacao.assinar.anexo.despacho", "01/01/2020");
 		addPublicProperty("debug.modelo.padrao.arquivo", null);
 		addPublicProperty("dje.lista.destinatario.publicacao", null);
 		addPublicProperty("dje.servidor.data.disponivel", null);


### PR DESCRIPTION
Ao alterar a propriedade `data.obrigacao.assinar.anexo.despacho` [[ref](https://github.com/codata-gedes/pbdoc/blob/50be30c23d9bf694b93dac9ef548344b9b80689f/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMobil.java#L1493)], o botão de criação de volumes só ficará habilitado se todos os anexos estiverem assinados.