### PR TITLE
Inclusão de Unidade Receptora em Lotação

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1769,7 +1769,7 @@ public class CpBL {
 	
 	public DpLotacao criarLotacao(final CpIdentidade identidadeCadastrante, final DpPessoa titular, final DpLotacao lotaTitular, 
 			final Long id, final String nmLotacao, final Long idOrgaoUsu, final String siglaLotacao,
-			final String situacao, final Boolean isExternaLotacao, final Long lotacaoPai, final Long idLocalidade) {
+			final String situacao, final Boolean isExternaLotacao, final Long lotacaoPai, final Long idLocalidade, final Boolean unidadeReceptora) {
 		if(nmLotacao == null)
 			throw new AplicacaoException("Nome da lotação não informado");
 		
@@ -1819,7 +1819,8 @@ public class CpBL {
 										|| (lotacaoPai != null && lotacao.getLotacaoPai() == null)
 										|| (lotacaoPai == null && lotacao.getLotacaoPai() != null)
 										|| (lotacaoPai != null && !lotacaoPai.equals(lotacao.getLotacaoPai() != null ? lotacao.getLotacaoPai().getId() : 0L))
-										|| !idLocalidade.equals(lotacao.getLocalidade().getId())))) {
+										|| !idLocalidade.equals(lotacao.getLocalidade().getId())
+										|| !unidadeReceptora.equals(lotacao.getUnidadeReceptora())))) {
 			if (id != null) {			
 				listPessoa = CpDao.getInstance().pessoasPorLotacao(id, Boolean.TRUE, Boolean.FALSE);
 				long qtdeDocumentoCriadosPosse = dao().consultarQtdeDocCriadosPossePorDpLotacao(lotacao.getIdInicial());
@@ -1862,7 +1863,7 @@ public class CpBL {
 			}
 			lotacaoNova.setNomeLotacao(Texto.removerEspacosExtra(nmLotacao).trim());
 			lotacaoNova.setSiglaLotacao(siglaLotacao.toUpperCase());
-			
+			lotacaoNova.setUnidadeReceptora(unidadeReceptora);
 			CpLocalidade localidade = new CpLocalidade();
 			localidade.setIdLocalidade(idLocalidade);
 			lotacaoNova.setLocalidade(dao().consultarLocalidade(localidade));

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpLotacao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/AbstractDpLotacao.java
@@ -184,6 +184,9 @@ public abstract class AbstractDpLotacao extends DpResponsavel implements
 	@Column(name = "IS_SUSPENSA")
 	private Integer isSuspensa;
 
+	@Column(name = "UNIDADE_RECEPTORA")
+	private Boolean unidadeReceptora;
+	
 	public Integer getIsExternaLotacao() {
 		return isExternaLotacao;
 	}
@@ -415,6 +418,14 @@ public abstract class AbstractDpLotacao extends DpResponsavel implements
 
 	public void setIsSuspensa(Integer isSuspensa) {
 		this.isSuspensa = isSuspensa;
+	}
+
+	public Boolean getUnidadeReceptora() {
+		return unidadeReceptora;
+	}
+
+	public void setUnidadeReceptora(Boolean unidadeReceptora) {
+		this.unidadeReceptora = unidadeReceptora;
 	}
 
 }

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
@@ -339,6 +339,7 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 			result.include("idOrgaoUsu", lotacao.getOrgaoUsuario().getId());
 			result.include("nmOrgaousu", lotacao.getOrgaoUsuario().getNmOrgaoUsu());
 			result.include("dtFimLotacao", lotacao.getDataFimLotacao());
+			result.include("unidadeReceptora", lotacao.getUnidadeReceptora());
 			result.include("isExternaLotacao", lotacao.getIsExternaLotacao());
 			if (lotacao.getLotacaoPai() != null)
 				result.include("lotacaoPai", lotacao.getLotacaoPai().getIdLotacao());
@@ -380,14 +381,19 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Transacional
 	@Post("/app/lotacao/gravar")
 	public void editarGravar(final Long id, final String nmLotacao, final Long idOrgaoUsu, final String siglaLotacao,
-			final String situacao, final Boolean isExternaLotacao, final Long lotacaoPai, final Long idLocalidade)
+			final String situacao, final Boolean isExternaLotacao, final Long lotacaoPai, final Long idLocalidade, final boolean unidadeReceptora)
 			throws Exception {
 
 		assertAcesso("GI:Módulo de Gestão de Identidade;CAD_LOTACAO: Cadastrar Lotação");
 
-		Cp.getInstance().getBL().criarLotacao(getIdentidadeCadastrante(), getTitular(), getTitular().getLotacao(), id,
-				nmLotacao, idOrgaoUsu, siglaLotacao, situacao, isExternaLotacao, lotacaoPai, idLocalidade);
-		this.result.include("mensagem", "Operação realizada com sucesso!");
+		DpLotacao lotacaoFoiCriada = Cp.getInstance().getBL().criarLotacao(getIdentidadeCadastrante(), getTitular(), getTitular().getLotacao(), id,
+				nmLotacao, idOrgaoUsu, siglaLotacao, situacao, isExternaLotacao, lotacaoPai, idLocalidade, unidadeReceptora);
+		
+		if (lotacaoFoiCriada != null) {		
+			this.result.include("mensagem", "Operação realizada com sucesso!");
+		} else {
+			this.result.include("mensagem", "Não foram realizadas quaisquer alterações!");
+		}
 		this.result.redirectTo(this).lista(0, null, "");
 
 	}

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
@@ -250,14 +250,14 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 			if (idOrgaoUsu == null) {
 				final CpOrgaoUsuario primeiroOrgaoUsuario = Iterables.getFirst(list, null);
 				final Long primeiroIdOrgaoUsuario = primeiroOrgaoUsuario != null ? primeiroOrgaoUsuario.getId() : null;
-				carregarCombos(null, primeiroIdOrgaoUsuario, null, null, null, null, null, 0, Boolean.FALSE);
+				carregarCombos(null, primeiroIdOrgaoUsuario, null, null, null, null, null, 0, Boolean.FALSE, Boolean.FALSE);
 			}
 		} else {
 			ou = CpDao.getInstance().consultarPorSigla(getTitular().getOrgaoUsuario());
 			list.add(ou);
 			result.include("orgaosUsu", list);
 			if (idOrgaoUsu == null) {
-				carregarCombos(null, ou.getId(), null, null, null, null, null, 0, Boolean.FALSE);
+				carregarCombos(null, ou.getId(), null, null, null, null, null, 0, Boolean.FALSE, Boolean.FALSE);
 			}
 		}
 		if (idOrgaoUsu != null && (CpConfiguracaoBL.SIGLA_ORGAO_ROOT.equals(getTitular().getOrgaoUsuario().getSigla()) || CpConfiguracaoBL.SIGLA_ORGAO_CODATA_ROOT.equals(getTitular().getOrgaoUsuario().getSigla())
@@ -305,7 +305,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 			result.include("idLotacaoPesquisa", idLotacaoPesquisa);
 			if (getItens().size() == 0) result.include("mensagemPesquisa", "Nenhum resultado encontrado.");			
 
-			carregarCombos(null, idOrgaoUsu, null, null, null, null, cpfPesquisa, paramoffset, Boolean.FALSE);
+			carregarCombos(null, idOrgaoUsu, null, null, null, null, cpfPesquisa, paramoffset, Boolean.FALSE, Boolean.FALSE);
 		}		
 	}
 
@@ -531,7 +531,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	@Post("/app/pessoa/carregarCombos")
 	public void carregarCombos(final Long id, final Long idOrgaoUsu, final String nmPessoa, final String dtNascimento,
 			final String cpf, final String email, final String cpfPesquisa, final Integer paramoffset,
-			Boolean retornarEnvioEmail) {
+			Boolean retornarEnvioEmail, final Boolean comUnidadeReceptora) {
 		result.include("request", getRequest());
 		result.include("id", id);
 		result.include("idOrgaoUsu", idOrgaoUsu);
@@ -739,14 +739,14 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 			list.remove(0);
 			result.include("orgaosUsu", list);
 			if (idOrgaoUsu == null) {
-				carregarCombos(null, idOrgaoUsu, null, null, null, null, null, 0, Boolean.TRUE);
+				carregarCombos(null, idOrgaoUsu, null, null, null, null, null, 0, Boolean.TRUE, Boolean.FALSE);
 			}
 		} else {
 			ou = CpDao.getInstance().consultarPorSigla(getTitular().getOrgaoUsuario());
 			list.add(ou);
 			result.include("orgaosUsu", list);
 			if (idOrgaoUsu == null) {
-				carregarCombos(null, ou.getId(), null, null, null, null, null, 0, Boolean.TRUE);
+				carregarCombos(null, ou.getId(), null, null, null, null, null, 0, Boolean.TRUE, Boolean.FALSE);
 			}
 		}
 		if (idOrgaoUsu != null && (CpConfiguracaoBL.SIGLA_ORGAO_ROOT.equals(getTitular().getOrgaoUsuario().getSigla()) || CpConfiguracaoBL.SIGLA_ORGAO_CODATA_ROOT.equals(getTitular().getOrgaoUsuario().getSigla())
@@ -781,7 +781,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 			result.include("idLotacaoPesquisa", idLotacaoPesquisa);
 			result.include("idUsuarioPesquisa", idUsuarioPesquisa);
 			this.result.include("mensagem", "Operação realizada com sucesso!");
-			carregarCombos(null, idOrgaoUsu, null, null, null, null, cpfPesquisa, paramoffset, Boolean.TRUE);
+			carregarCombos(null, idOrgaoUsu, null, null, null, null, cpfPesquisa, paramoffset, Boolean.TRUE, Boolean.FALSE);
 		}
 	}
 	
@@ -915,7 +915,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 					result.include("mensagemPesquisa", "Nenhum resultado encontrado.");
 					result.include("temPermissaoParaExportarDados", temPermissaoParaExportarDados());
 
-					carregarCombos(null, idOrgaoUsu, null, null, null, null, cpfPesquisa, 0, Boolean.FALSE);																						
+					carregarCombos(null, idOrgaoUsu, null, null, null, null, cpfPesquisa, 0, Boolean.FALSE, Boolean.FALSE);																						
 			}					
 		}
 

--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/edita.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/edita.jsp
@@ -12,6 +12,7 @@
 		var siglaLotacao = document.getElementsByName('siglaLotacao')[0].value;		
 		var id = document.getElementsByName('id')[0].value;
 		var idLocalidade = document.getElementsByName('idLocalidade')[0].value;	
+		var unidadeReceptora = document.getElementsByName('unidadeReceptora')[0].value;
 		if (nmLotacao==null || nmLotacao=="") {
 			habilitarBotaoOk();
 			sigaModal.alerta("Preencha o nome da Lotação");
@@ -163,6 +164,16 @@
 									<input type="radio" name="situacao" value="false" id="situacaoInativo" ${not empty dtFimLotacao ? 'checked' : ''} />Inativo
 								</label>
 							</div>							
+						</div>
+					</div>
+					<div class="col-sm-3">
+						<div class="form-group">
+							<label for="unidadeReceptora">Unidade Receptora</label><br/>
+							<div class="form-check-inline">
+								<label class="form-check-label">
+									<input type="checkbox" id="unidadeReceptora" name="unidadeReceptora" ${unidadeReceptora eq true ? 'checked' : ''} />									
+								</label>
+							</div>
 						</div>
 					</div>
 				</div>

--- a/siga/src/main/webapp/WEB-INF/page/dpLotacao/lista.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpLotacao/lista.jsp
@@ -95,7 +95,8 @@
                 <tr>
                     <th align="left">Nome</th>
                     <th align="left">Sigla</th>
-                    <th align="left">Externa</th>
+                    <th hidden="true" align="left">Externa</th>
+                    <th align="left">Unidade Receptora</th>
                     <th align="left">Suspensa</th>
                     <th colspan="2" align="center">Op&ccedil;&otilde;es</th>
                 </tr>
@@ -107,8 +108,9 @@
                     <tr>
                         <td align="left">${lotacao.descricao}</td>
                         <td align="left">${lotacao.sigla}</td>
-                        <td align="left">${lotacao.isExternaLotacao == 1 ? 'SIM' : 'NÃO'}</td>
-                        <td align="left">${lotacao.isSuspensa == 1 ? 'SIM' : 'NÃO'}</td>
+                        <td align="left" style="${lotacao.unidadeReceptora == true ? 'color : red' : ''}">${lotacao.unidadeReceptora == true ? 'SIM' : 'NÃO'}</td>
+                        <td hidden="true" align="left">${lotacao.isExternaLotacao == 1 ? 'SIM' : 'NÃO'}</td>
+                        <td align="left" style="${lotacao.isSuspensa == 1 ? 'color : red' : ''}">${lotacao.isSuspensa == 1 ? 'SIM' : 'NÃO'}</td>
                         <td align="left">
                             <c:url var="url" value="/app/lotacao/editar">
                                 <c:param name="id" value="${lotacao.id}"></c:param>


### PR DESCRIPTION
Inserção de checkbox "Unidade Receptora".
Resta apenas bloquear visualização e/ou listagem das lotações que a Unidade Receptora esta false.

Necessita realizar execução do script SQL no banco antes do deploy.

```sql
alter table corporativo.dp_lotacao add "unidade_receptora" bool default false not null;
```