### PR TITLE
[BugFix] Alerta "a devolver fora do prazo"

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorEnum.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/model/enm/CpMarcadorEnum.java
@@ -114,7 +114,7 @@ public enum CpMarcadorEnum {
 	//
 	A_DEVOLVER(56, "A Devolver", "fas fa-exchange-alt", EMPTY, CpMarcadorGrupoEnum.AGUARDANDO_ANDAMENTO),
 	//
-	AGUARDANDO(57, "Aguardando", "fas fa-clock", EMPTY, CpMarcadorGrupoEnum.AGUARDANDO_ANDAMENTO),
+	AGUARDANDO_DEVOLUCAO(57, "Aguardando Devolução", "fas fa-clock", EMPTY, CpMarcadorGrupoEnum.AGUARDANDO_ANDAMENTO),
 	//
 	A_DEVOLVER_FORA_DO_PRAZO(58, "A Devolver Fora do Prazo", "fas fa-exchange-alt", EMPTY, CpMarcadorGrupoEnum.ALERTA),
 	//

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMovimentacao.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/ExMovimentacao.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1308,6 +1309,15 @@ public class ExMovimentacao extends AbstractExMovimentacao implements
 	@Override
 	public String getNomeTabela() {
 		return ExArquivoFilesystem.TABELA_EX_MOVIMENTACAO;
+	}
+	
+	public boolean isTransferenciaRetorno() {
+		if (this.getExTipoMovimentacao().getIdTpMov() != ExTipoMovimentacao.TIPO_MOVIMENTACAO_TRANSFERENCIA) {
+			return false;
+		}
+		
+		return this.mob().getDoc().getCadastrante().equals(this.getResp()) || 
+				this.mob().getDoc().getLotaCadastrante().equals(this.getLotaResp());
 	}
 
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
@@ -596,7 +596,7 @@ public class ExMarcadorBL {
 	public void calcularMarcadoresTransferencia(Date dt) {
 		long m_aDevolverFora = CpMarcadorEnum.A_DEVOLVER_FORA_DO_PRAZO.getId();
 		long m_aDevolver = CpMarcadorEnum.A_DEVOLVER.getId();
-		long m_aguardando = CpMarcadorEnum.AGUARDANDO.getId();
+		long m_aguardando = CpMarcadorEnum.AGUARDANDO_DEVOLUCAO.getId();
 		long m_aguardandoFora = CpMarcadorEnum.AGUARDANDO_DEVOLUCAO_FORA_DO_PRAZO.getId();
 
 		List<ExMovimentacao> transferencias = mob.getMovimentacoesPorTipo(3, false);

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExMarcadorBL.java
@@ -624,8 +624,9 @@ public class ExMarcadorBL {
 
 			ExMovimentacao movRetorno = contemTransferenciaRetorno(transfComData, mobil);
 
-			if (movRetorno != null) {
+			if (movRetorno != null || !transferencias.contains(transfComData)) {
 				transferencias.remove(movRetorno);
+				transferencias.remove(transfComData);
 			} else {
 				Date dtMarca = transfComData.getDtFimMov();
 				dtMarca.setHours(23);

--- a/siga-vraptor-module/src/main/resources/META-INF/tags/rodape.tag
+++ b/siga-vraptor-module/src/main/resources/META-INF/tags/rodape.tag
@@ -61,6 +61,7 @@
 				this.beenSubmitted = true;
 		});
  		$('.campoData').datepicker({
+ 			minDate: '0',
            	onSelect: function(){
                    ${onSelect}
 			}

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExMovimentacaoController.java
@@ -1883,7 +1883,7 @@ public class ExMovimentacaoController extends ExController {
 		// set dtDevolucaoMovString baseado na data fim do tramite.
 		ExMobil mob = builder.getMob();
 		ExMovimentacao ultimaMovimentacao = mob.getUltimaMovimentacao(new long[] { ExTipoMovimentacao.TIPO_MOVIMENTACAO_TRANSFERENCIA}, null, mob, false, null);
-		if (ultimaMovimentacao != null && ultimaMovimentacao.getDtFimMov() != null) {
+		if (ultimaMovimentacao != null && ultimaMovimentacao.getDtFimMov() != null && !ultimaMovimentacao.isTransferenciaRetorno()) {
 			dtDevolucaoMovString = ultimaMovimentacao.getDtFimMovDDMMYYYY().toString();
 		}
 

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExSelecionavelController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExSelecionavelController.java
@@ -68,7 +68,7 @@ public abstract class ExSelecionavelController<T extends Selecionavel, DaoFiltro
 				CpMarcadorEnum.A_RECEBER.getId(), 
 				CpMarcadorEnum.A_REMETER_MANUALMENTE.getId(),
 				CpMarcadorEnum.A_REMETER_PARA_PUBLICACAO.getId(),
-				CpMarcadorEnum.AGUARDANDO.getId(),
+				CpMarcadorEnum.AGUARDANDO_DEVOLUCAO.getId(),
 				CpMarcadorEnum.AGUARDANDO_DEVOLUCAO_FORA_DO_PRAZO.getId(),
 				CpMarcadorEnum.ANEXO_PENDENTE_DE_ASSINATURA.getId(),
 				CpMarcadorEnum.APENSADO.getId(), 


### PR DESCRIPTION
Correção para o seguinte caso: documentos tramitados com 'data de devolução marcada' no ato da tramitação, ao voltar ao subscritor, não estão saindo do status de Alertas de devolução, nas suas mesas virtuais.