### PR TITLE
Correção listagem de lotações em unidade receptora e cadastro de pessoa.

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -742,16 +742,20 @@ public class CpDao extends ModeloDao {
 
 			final String principal = ContextoPersistencia.getUserPrincipal();
 			final CpIdentidade identidadePrincipal = consultaIdentidadeCadastrante(principal, true);
-
-			if (filtro.getIdOrgaoUsu() != null && filtro.getIdOrgaoUsu().longValue() > 0) {
+			
+			if((CpConfiguracaoBL.SIGLA_ORGAO_ROOT.equals(identidadePrincipal.getCpOrgaoUsuario().getSigla()) || 
+					CpConfiguracaoBL.SIGLA_ORGAO_CODATA_ROOT.equals(identidadePrincipal.getCpOrgaoUsuario().getSigla())) && filtro.isBuscarParaCadastroDePessoa()) {
 				predicates.and(qCpOrgaoUsuario.idOrgaoUsu.eq(filtro.getIdOrgaoUsu()));
-
-				if (!identidadePrincipal.getCpOrgaoUsuario().getId().equals(filtro.getIdOrgaoUsu())) {
-					predicates.and(qDpLotacao.unidadeReceptora.isTrue());
-				}
 			} else {
-				predicates.and(qCpOrgaoUsuario.idOrgaoUsu.eq(identidadePrincipal.getCpOrgaoUsuario().getId()));
-				predicates.or(qDpLotacao.unidadeReceptora.isTrue());
+				if (filtro.getIdOrgaoUsu() != null && filtro.getIdOrgaoUsu().longValue() > 0) {
+					predicates.and(qCpOrgaoUsuario.idOrgaoUsu.eq(filtro.getIdOrgaoUsu()));
+					if (!identidadePrincipal.getCpOrgaoUsuario().getId().equals(filtro.getIdOrgaoUsu())) {
+						predicates.and(qDpLotacao.unidadeReceptora.isTrue());
+					}
+				} else {
+					predicates.and(qCpOrgaoUsuario.idOrgaoUsu.eq(identidadePrincipal.getCpOrgaoUsuario().getId()));
+					predicates.or(qDpLotacao.unidadeReceptora.isTrue());
+				}
 			}
 		}
 

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/DpLotacaoDaoFiltro.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/DpLotacaoDaoFiltro.java
@@ -31,6 +31,8 @@ public class DpLotacaoDaoFiltro extends DaoFiltroSelecionavel {
 
 	private boolean buscarSemLimitarOrgaoOrigem;
 	
+	private boolean buscarParaCadastroDePessoa;
+	
 	public DpLotacaoDaoFiltro() {}
 	
 	public DpLotacaoDaoFiltro(String nome, Long idOrgaoUsu) {
@@ -54,6 +56,13 @@ public class DpLotacaoDaoFiltro extends DaoFiltroSelecionavel {
 		this.buscarSemLimitarOrgaoOrigem = buscarSemLimitarOrgaoOrigem;
 	}
 
+	public boolean isBuscarParaCadastroDePessoa() {
+		return buscarParaCadastroDePessoa;
+	}
+
+	public void setBuscarParaCadastroDePessoa(boolean buscarParaCadastroDePessoa) {
+		this.buscarParaCadastroDePessoa = buscarParaCadastroDePessoa;
+	}
 	public String getNome() {
 		return nome;
 	}
@@ -85,4 +94,5 @@ public class DpLotacaoDaoFiltro extends DaoFiltroSelecionavel {
 
 		setSigla(MatriculaUtils.getSiglaDaLotacao(siglaCompleta));
 	}
+
 }

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
@@ -262,37 +262,37 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 		}
 		if (idOrgaoUsu != null && (CpConfiguracaoBL.SIGLA_ORGAO_ROOT.equals(getTitular().getOrgaoUsuario().getSigla()) || CpConfiguracaoBL.SIGLA_ORGAO_CODATA_ROOT.equals(getTitular().getOrgaoUsuario().getSigla())
 				|| CpDao.getInstance().consultarPorSigla(getTitular().getOrgaoUsuario()).getId().equals(idOrgaoUsu))) {
-			DpPessoaDaoFiltro dpPessoa = new DpPessoaDaoFiltro();
-			dpPessoa.setBuscarFechadas(buscarInativos);
+			DpPessoaDaoFiltro dpPessoaFiltro = new DpPessoaDaoFiltro();
+			dpPessoaFiltro.setBuscarFechadas(buscarInativos);
 			if (paramoffset == null) {
 				paramoffset = 0;
 			}
-			dpPessoa.setIdOrgaoUsu(idOrgaoUsu);
-			dpPessoa.setNome(isNotBlank(nome) ? Texto.removeAcento(nome) : EMPTY);
-			dpPessoa.setEmail(isNotBlank(emailPesquisa) ? Texto.removeAcento(emailPesquisa) : EMPTY);
-			dpPessoa.setIdentidade(identidadePesquisa);
+			dpPessoaFiltro.setIdOrgaoUsu(idOrgaoUsu);
+			dpPessoaFiltro.setNome(isNotBlank(nome) ? Texto.removeAcento(nome) : EMPTY);
+			dpPessoaFiltro.setEmail(isNotBlank(emailPesquisa) ? Texto.removeAcento(emailPesquisa) : EMPTY);
+			dpPessoaFiltro.setIdentidade(identidadePesquisa);
 			if(idCargoPesquisa != null) {
 				DpCargo cargo = new DpCargo();
 				cargo.setId(idCargoPesquisa);
-				dpPessoa.setCargo(cargo);
+				dpPessoaFiltro.setCargo(cargo);
 			}
 			if (idLotacaoPesquisa != null) {
 				DpLotacao lotacao = new DpLotacao();
 				lotacao.setId(idLotacaoPesquisa);
-				dpPessoa.setLotacao(lotacao);
+				dpPessoaFiltro.setLotacao(lotacao);
 			}
 			if (idFuncaoPesquisa != null) {
 				DpFuncaoConfianca funcao = new DpFuncaoConfianca();
 				funcao.setIdFuncao(idFuncaoPesquisa);
-				dpPessoa.setFuncaoConfianca(funcao);
+				dpPessoaFiltro.setFuncaoConfianca(funcao);
 			}
 			if (isNotBlank(cpfPesquisa)) {
-				dpPessoa.setCpf(Long.valueOf(cpfPesquisa.replace(".", EMPTY).replace("-", EMPTY)));
+				dpPessoaFiltro.setCpf(Long.valueOf(cpfPesquisa.replace(".", EMPTY).replace("-", EMPTY)));
 			}
-			dpPessoa.setId(Long.valueOf(0));
-			setItens(CpDao.getInstance().consultarPorFiltro(dpPessoa, paramoffset, 15));
+			dpPessoaFiltro.setId(Long.valueOf(0));
+			setItens(CpDao.getInstance().consultarPorFiltro(dpPessoaFiltro, paramoffset, 15));
 			result.include("itens", getItens());
-			long tamanho = dao().consultarQuantidade(dpPessoa);
+			long tamanho = dao().consultarQuantidade(dpPessoaFiltro);
 			result.include("tamanho", tamanho);
 
 			result.include("idOrgaoUsu", idOrgaoUsu);
@@ -575,6 +575,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 		DpLotacaoDaoFiltro lotacao = new DpLotacaoDaoFiltro();
 		lotacao.setNome("");
 		lotacao.setIdOrgaoUsu(idOrgaoUsu);
+		lotacao.setBuscarParaCadastroDePessoa(true);
 		List<DpLotacao> listaLotacao = new ArrayList<DpLotacao>();
 		DpLotacao l = new DpLotacao();
 		l.setNomeLotacao("Selecione");


### PR DESCRIPTION
A presente solicitação de Merge resolve o seguinte problema:

- Em cadastro de pessoas estava listando apenas as unidades receptoras, agora lista todas os órgãos e suas respectivas lotações (caso ROOT ou CODATA). 
- Para os demais que tiverem permissão de cadastro apenas está sendo listada as lotações de seu próprio Órgão.
- Em criação de documento o processo continua o mesmo, listando as próprias lotações e se tiver permissão para tramitar externo também será listados os orgãos e suas unidades receptoras disponíveis.
