### PR TITLE
[BugFix] NPE para casos onde o subscritor é nulo

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExCompetenciaBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExCompetenciaBL.java
@@ -889,8 +889,8 @@ public class ExCompetenciaBL extends CpCompetenciaBL {
 					CpTipoConfiguracao.TIPO_CONFIG_MOVIMENTAR, null, null, null, null, null, null))
 				return false;				
 		} else {
-			if(mob.doc().getSubscritor() == null || !mob.doc().getSubscritor().equivale(titular)) {
-				if (!mob.doc().getCadastrante().equivale(titular)) return false;
+			if(mob.doc().getSubscritor() != null && !mob.doc().getSubscritor().equivale(titular)) {
+				return false;
 			} 
 			if (!podeSerTransferido(mob) && mob.doc().isDocFilhoJuntadoAoPai()) {  
 				return false;

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExCompetenciaBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExCompetenciaBL.java
@@ -889,8 +889,8 @@ public class ExCompetenciaBL extends CpCompetenciaBL {
 					CpTipoConfiguracao.TIPO_CONFIG_MOVIMENTAR, null, null, null, null, null, null))
 				return false;				
 		} else {
-			if(!mob.doc().getSubscritor().equivale(titular)) {
-				return false;
+			if(mob.doc().getSubscritor() == null || !mob.doc().getSubscritor().equivale(titular)) {
+				if (!mob.doc().getCadastrante().equivale(titular)) return false;
 			} 
 			if (!podeSerTransferido(mob) && mob.doc().isDocFilhoJuntadoAoPai()) {  
 				return false;


### PR DESCRIPTION
Esta PR corrige a `NullPointerException` lançada quando o subscritor é nulo.