### PR TITLE
Unidade receptora

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -1509,11 +1509,13 @@ public class CpDao extends ModeloDao {
 				predicates.and(qDpPessoa.dataFimPessoa.isNull());
 				predicates.and(predicadoExisteIdentidadeAtivaParaPessoa(qDpPessoa, qCpIdentidade));
 				
-				if(!(CpConfiguracaoBL.SIGLA_ORGAO_ROOT.equals(identidadePrincipal.getCpOrgaoUsuario().getSigla()) || 
+				if((CpConfiguracaoBL.SIGLA_ORGAO_ROOT.equals(identidadePrincipal.getCpOrgaoUsuario().getSigla()) || 
 					CpConfiguracaoBL.SIGLA_ORGAO_CODATA_ROOT.equals(identidadePrincipal.getCpOrgaoUsuario().getSigla()))) {
+					predicates.and(qDpPessoa.lotacao.unidadeReceptora.isFalse());
+				} else {
 					if (!identidadePrincipal.getCpOrgaoUsuario().getId().equals(filtro.getIdOrgaoUsu())) {
 						predicates.and(qDpPessoa.lotacao.unidadeReceptora.isTrue());
-					} 
+					}
 				}
 				
 			}

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -1509,8 +1509,7 @@ public class CpDao extends ModeloDao {
 				predicates.and(qDpPessoa.dataFimPessoa.isNull());
 				predicates.and(predicadoExisteIdentidadeAtivaParaPessoa(qDpPessoa, qCpIdentidade));
 				
-				if((CpConfiguracaoBL.SIGLA_ORGAO_ROOT.equals(identidadePrincipal.getCpOrgaoUsuario().getSigla()) || 
-					CpConfiguracaoBL.SIGLA_ORGAO_CODATA_ROOT.equals(identidadePrincipal.getCpOrgaoUsuario().getSigla()))) {
+				if((CpConfiguracaoBL.SIGLA_ORGAO_ROOT.equals(identidadePrincipal.getCpOrgaoUsuario().getSigla()))) {
 					predicates.and(qDpPessoa.lotacao.unidadeReceptora.isFalse());
 				} else {
 					if (!identidadePrincipal.getCpOrgaoUsuario().getId().equals(filtro.getIdOrgaoUsu())) {

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
@@ -481,6 +481,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 				DpLotacaoDaoFiltro lotacao = new DpLotacaoDaoFiltro();
 				lotacao.setNome("");
 				lotacao.setIdOrgaoUsu(ou.getId());
+				lotacao.setBuscarParaCadastroDePessoa(true);
 				List<DpLotacao> listaLotacao = new ArrayList<DpLotacao>();
 				DpLotacao l = new DpLotacao();
 				l.setNomeLotacao("Selecione");


### PR DESCRIPTION
Ajuste da unidade receptora com bloqueio de envio para usuários que a unidade receptora esteja como TRUE.
Ajuste em Cadastro de Pessoa que ao editar um usuário estava apenas listando unidades receptoras TRUE ao invés de listar todas do órgão.