### PR TITLE
[BugFix] Criar identidades de usuários ao editar lotação

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1875,7 +1875,7 @@ public class CpBL {
 				if(lotacao != null && lotacao.getId() != null) {
 					
 					DpPessoa pessoaNova = null;
-					List<DpPessoa> listPessoa = CpDao.getInstance().pessoasPorLotacao(id, Boolean.TRUE, Boolean.FALSE);
+					List<DpPessoa> listPessoa = CpDao.getInstance().consultaPessoasPorLotacao(lotacao);
 					for (DpPessoa dpPessoa : listPessoa) {
 						pessoaNova = DpPessoa.novaInstanciaBaseadaEm(dpPessoa, data);
 						if(dpPessoa.getLotacao().getIdInicial().equals(lotacaoNova.getIdLotacaoIni())) {

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1875,7 +1875,7 @@ public class CpBL {
 				if(lotacao != null && lotacao.getId() != null) {
 					
 					DpPessoa pessoaNova = null;
-					List<DpPessoa> listPessoa = CpDao.getInstance().consultaPessoasPorLotacao(lotacao);
+					List<DpPessoa> listPessoa = CpDao.getInstance().consultaPessoasPorLotacao(lotacao, false);
 					for (DpPessoa dpPessoa : listPessoa) {
 						pessoaNova = DpPessoa.novaInstanciaBaseadaEm(dpPessoa, data);
 						if(dpPessoa.getLotacao().getIdInicial().equals(lotacaoNova.getIdLotacaoIni())) {

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1862,8 +1862,6 @@ public class CpBL {
 			}
 			
 			lotacaoNova.setDataInicioLotacao(data);
-			DpLotacao lotacaoFilhoNova = null;
-			DpLotacao lotacaoFilhoAntiga = null;
 			try {
 				if(lotacaoNova.getDataFimLotacao() != null) {
 					lotacao.setDataFimLotacao(lotacaoNova.getDataFimLotacao());
@@ -1874,27 +1872,16 @@ public class CpBL {
 				
 				if(lotacao != null && lotacao.getId() != null) {
 					
-					DpPessoa pessoaNova = null;
 					List<DpPessoa> listPessoa = CpDao.getInstance().consultaPessoasPorLotacao(lotacao, false);
 					for (DpPessoa dpPessoa : listPessoa) {
-						pessoaNova = DpPessoa.novaInstanciaBaseadaEm(dpPessoa, data);
-						if(dpPessoa.getLotacao().getIdInicial().equals(lotacaoNova.getIdLotacaoIni())) {
-							pessoaNova.setLotacao(lotacaoNova);
-						} else {
-							if(dpPessoa.getLotacao().getLotacaoPai() != null && lotacaoNova.getId().equals(dpPessoa.getLotacao().getLotacaoAtual().getLotacaoPai().getId())) {
-								pessoaNova.setLotacao(dpPessoa.getLotacao().getLotacaoAtual());
-							} else {
-								//grava nova lotacao filho e setar na pessoa
-								lotacaoFilhoNova = new DpLotacao();
-								lotacaoFilhoAntiga =  dpPessoa.getLotacao().getLotacaoAtual();
-								
-								lotacaoFilhoNova.setDataInicio(data);
-								copiaLotacao(lotacaoFilhoAntiga, lotacaoFilhoNova);
-								
-								dao().gravarComHistorico(lotacaoFilhoNova, lotacaoFilhoAntiga, data, identidadeCadastrante);
-								pessoaNova.setLotacao(lotacaoFilhoNova);
-							}
-						}				
+						DpPessoa pessoaNova = DpPessoa.novaInstanciaBaseadaEm(dpPessoa, data);
+						pessoaNova.setLotacao(lotacaoNova);
+						
+						if (dpPessoa.getDataFimPessoa() != null) {
+							pessoaNova.setDataFimPessoa(data);
+							pessoaNova.setHisIdcFim(identidadeCadastrante);
+						}
+						
 						dao().gravarComHistorico(pessoaNova, dpPessoa, data, identidadeCadastrante);
 						criarIdentidadeComHistorico(data, dpPessoa, pessoaNova, identidadeCadastrante);
 					}

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -1511,16 +1511,16 @@ public class CpDao extends ModeloDao {
 				predicates.and(qDpPessoa.dataFimPessoa.isNull());
 				predicates.and(predicadoExisteIdentidadeAtivaParaPessoa(qDpPessoa, qCpIdentidade));
 				
-//				if(CpConfiguracaoBL.SIGLA_ORGAO_ROOT.equals(identidadePrincipal.getCpOrgaoUsuario().getSigla())) {
-//					predicates.and(qDpPessoa.lotacao.unidadeReceptora.isFalse());
-//				} else {
-//					if (!identidadePrincipal.getCpOrgaoUsuario().getId().equals(filtro.getIdOrgaoUsu())) {
-//						predicates.and(
-//								qDpPessoa.orgaoUsuario.codOrgaoUsu.eq(identidadePrincipal.getCpOrgaoUsuario().getId())
-//									.or(qDpPessoa.lotacao.unidadeReceptora.isTrue())
-//						);						
-//					} 
-//				}
+				if(CpConfiguracaoBL.SIGLA_ORGAO_ROOT.equals(identidadePrincipal.getCpOrgaoUsuario().getSigla())) {
+					predicates.and(qDpPessoa.lotacao.unidadeReceptora.isFalse());
+				} else {
+					if (!identidadePrincipal.getCpOrgaoUsuario().getId().equals(filtro.getIdOrgaoUsu())) {
+						predicates.and(
+								qDpPessoa.orgaoUsuario.codOrgaoUsu.eq(identidadePrincipal.getCpOrgaoUsuario().getId())
+									.or(qDpPessoa.lotacao.unidadeReceptora.isTrue())
+						);						
+					} 
+				}
 			
 			}
 

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -1827,6 +1827,23 @@ public class CpDao extends ModeloDao {
 		return query.fetch();
 	}
 
+	
+	public List<DpPessoa> consultaPessoasPorLotacao(final DpLotacao lotacao) {
+		return this.consultaPessoasPorLotacao(lotacao, null);
+	}
+	
+	private List<DpPessoa> consultaPessoasPorLotacao(final DpLotacao lotacao, Integer limit) {
+		final JPAQuery<DpPessoa> query = new JPAQuery<DpPessoa>(em())
+				.from(qDpPessoa)
+				.where(qDpPessoa.lotacao.idLotacao.eq(lotacao.getId())
+						.and(qDpPessoa.dataFimPessoa.isNull()));
+		if (limit != null) {
+			query.limit(limit);
+		}
+		return query.fetch();
+	}
+
+	
 	/*
 	 * @SuppressWarnings("unchecked") public Usuario
 	 * consultaUsuarioCadastrante(final String nmUsuario) { try { final Query

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -1836,10 +1836,12 @@ public class CpDao extends ModeloDao {
 		if (selecionarApenasAtivos) {
 			predicates.and(qDpPessoa.dataFimPessoa.isNull());
 		} else {
+			final QDpPessoa subqDpPessoa = new QDpPessoa("subqDpPessoa");
 			final JPQLQuery<Long> subquery = JPAExpressions
-					.select(qDpPessoa.idPessoa.max())
-					.from(qDpPessoa)
-					.groupBy(qDpPessoa.idPessoaIni);
+					.select(subqDpPessoa.idPessoa.max())
+					.from(subqDpPessoa)
+					.where(subqDpPessoa.lotacao.idLotacao.eq(lotacao.getId()))
+					.groupBy(subqDpPessoa.idPessoaIni);
 			predicates.and(qDpPessoa.idPessoa.in(subquery));
 		}
 		


### PR DESCRIPTION
Esta PR atacou os seguintes pontos:

- [x] bug na consulta de listagem pessoas de uma dada lotação. Uma nova e mais eficiente consulta foi adicionada.
- [x] refatoramento da criação de identidade de usuários, inclusive de usuários inativos

Related to PR #292.