### PR TITLE
[BugFix] criar identidade pessoas para casos de histórico vazio

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1368,7 +1368,12 @@ public class CpBL {
 	}
 
 	public CpIdentidade criarIdentidadeComHistorico(Date dataCriacaoIdentidade, DpPessoa pessoaAnterior, DpPessoa pessoaNova, CpIdentidade identidadeCadastrante) {
-		final CpIdentidade identidadeAntiga = CpDao.getInstance().consultaIdentidade(pessoaAnterior);
+		CpIdentidade identidadeAntiga = CpDao.getInstance().consultaIdentidade(pessoaAnterior);
+		if (identidadeAntiga == null) {
+			identidadeAntiga = Cp.getInstance().getBL().criarIdentidade(pessoaAnterior.getSesbPessoa() + pessoaAnterior.getMatricula(),
+					pessoaAnterior.getCpfFormatado(), identidadeCadastrante, null, new String[1], Boolean.FALSE);
+		}
+		
 		final CpIdentidade identidadeNova = CpIdentidade.novaInstanciaBaseadaEm(identidadeAntiga, pessoaNova, dataCriacaoIdentidade);
 
 		CpDao.getInstance().gravarComHistorico(identidadeNova, identidadeAntiga, dataCriacaoIdentidade, identidadeCadastrante);

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -448,7 +448,7 @@ public class CpBL {
 	}
 
 	public CpIdentidade criarIdentidade(String matricula, String cpf, CpIdentidade idCadastrante,
-			final String senhaDefinida, String[] senhaGerada, boolean marcarParaSinc) throws AplicacaoException {
+			final String senhaDefinida, String[] senhaGerada, boolean marcarParaSinc, boolean enviarEmail) throws AplicacaoException {
 
 		Long longCpf = CPFUtils.getLongValueValidaSimples(cpf);
 		final List<DpPessoa> listaPessoas = dao().listarPorCpf(longCpf);
@@ -512,8 +512,10 @@ public class CpBL {
 							Correio.enviar(null,
 									destinanarios, "Novo Usuário", "", conteudoHTML);
 						} else {
-							Correio.enviar(pessoa.getEmailPessoaAtual(), "Novo Usuário",
-									textoEmailNovoUsuario(matricula, novaSenha, autenticaPeloBanco));
+							if (enviarEmail) {
+								Correio.enviar(pessoa.getEmailPessoaAtual(), "Novo Usuário",
+										textoEmailNovoUsuario(matricula, novaSenha, autenticaPeloBanco));
+							}
 						}
 						dao().commitTransacao();
 						return idNova;
@@ -1351,7 +1353,7 @@ public class CpBL {
 
 			if(enviarEmail != null && idOrgaoUsu != null && cpf != null && lista != null && lista.size() == 0) {
 				Cp.getInstance().getBL().criarIdentidade(pessoa.getSesbPessoa() + pessoa.getMatricula(),
-						pessoa.getCpfFormatado(), identidadeCadastrante, null, new String[1], Boolean.FALSE);
+						pessoa.getCpfFormatado(), identidadeCadastrante, null, new String[1], Boolean.FALSE, Boolean.TRUE);
 			}
 
 			return pessoa;
@@ -1371,7 +1373,7 @@ public class CpBL {
 		CpIdentidade identidadeAntiga = CpDao.getInstance().consultaIdentidade(pessoaAnterior);
 		if (identidadeAntiga == null) {
 			identidadeAntiga = Cp.getInstance().getBL().criarIdentidade(pessoaAnterior.getSesbPessoa() + pessoaAnterior.getMatricula(),
-					pessoaAnterior.getCpfFormatado(), identidadeCadastrante, null, new String[1], Boolean.FALSE);
+					pessoaAnterior.getCpfFormatado(), identidadeCadastrante, null, new String[1], Boolean.FALSE, Boolean.FALSE);
 		}
 		
 		final CpIdentidade identidadeNova = CpIdentidade.novaInstanciaBaseadaEm(identidadeAntiga, pessoaNova, dataCriacaoIdentidade);

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
@@ -823,7 +823,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 				senhaGerada[0] = GeraMessageDigest.geraSenha();
 			}
 			Cp.getInstance().getBL().criarIdentidade(dpPessoa2.getSesbPessoa() + dpPessoa2.getMatricula(),
-					dpPessoa2.getCpfFormatado(), getIdentidadeCadastrante(), null, senhaGerada, Boolean.FALSE);
+					dpPessoa2.getCpfFormatado(), getIdentidadeCadastrante(), null, senhaGerada, Boolean.FALSE, Boolean.TRUE);
 			cpfAnterior = dpPessoa2.getCpfPessoa().toString();
 		}
 		this.result.redirectTo(this).enviaEmail(0, idOrgaoUsu, nome, cpfPesquisa, idLotacaoPesquisa, idUsuarioPesquisa,0);


### PR DESCRIPTION
Para casos raros e antigos, não há histórico de identidade dos usuários. Esse problema impossibilita a edição do cadastro desses usuários e da lotação da qual fazem parte.

