### PR TITLE
[BugFix] criar identidades desconsiderando usuários realocados de lotação

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/bl/CpBL.java
@@ -1877,8 +1877,13 @@ public class CpBL {
 				
 				if(lotacao != null && lotacao.getId() != null) {
 					
-					List<DpPessoa> listPessoa = CpDao.getInstance().consultaPessoasPorLotacao(lotacao, false);
-					for (DpPessoa dpPessoa : listPessoa) {
+					DpPessoaDaoFiltro dpPessoaFiltro = new DpPessoaDaoFiltro();
+					dpPessoaFiltro.setBuscarFechadas(true);
+					dpPessoaFiltro.setBuscarParaCadastroDePessoas(true);
+					dpPessoaFiltro.setLotacao(lotacao);
+					
+					List<DpPessoa> pessoas = CpDao.getInstance().consultarPorFiltro(dpPessoaFiltro, 0, 0);
+					for (DpPessoa dpPessoa : pessoas) {
 						DpPessoa pessoaNova = DpPessoa.novaInstanciaBaseadaEm(dpPessoa, data);
 						pessoaNova.setLotacao(lotacaoNova);
 						

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -1508,18 +1508,18 @@ public class CpDao extends ModeloDao {
 		} else {
 			if (!filtro.isBuscarFechadas()) {
 				predicates.and(qDpPessoa.dataFimPessoa.isNull());
-				predicates.and(predicadoExisteIdentidadeAtivaParaPessoa(qDpPessoa, qCpIdentidade));
-				
-				if(!CpConfiguracaoBL.SIGLA_ORGAO_ROOT.equals(identidadePrincipal.getCpOrgaoUsuario().getSigla()) && !filtro.isBuscarParaCadastroDePessoas()) {
-					if (!identidadePrincipal.getCpOrgaoUsuario().getId().equals(filtro.getIdOrgaoUsu())) {
-						predicates.and(
-								qDpPessoa.orgaoUsuario.codOrgaoUsu.eq(identidadePrincipal.getCpOrgaoUsuario().getId())
-									.or(qDpPessoa.lotacao.unidadeReceptora.isTrue())
-						);						
-					} 
-				}
-			
 			}
+			
+			if(!CpConfiguracaoBL.SIGLA_ORGAO_ROOT.equals(identidadePrincipal.getCpOrgaoUsuario().getSigla()) && !filtro.isBuscarParaCadastroDePessoas()) {
+				if (!identidadePrincipal.getCpOrgaoUsuario().getId().equals(filtro.getIdOrgaoUsu())) {
+					predicates.and(
+							qDpPessoa.orgaoUsuario.codOrgaoUsu.eq(identidadePrincipal.getCpOrgaoUsuario().getId())
+								.or(qDpPessoa.lotacao.unidadeReceptora.isTrue())
+					);						
+				} 
+			}
+			
+			predicates.and(predicadoExisteIdentidadeAtivaParaPessoa(qDpPessoa, qCpIdentidade));
 
 			// ID passado no filtro é DIFERENTE do que contém no banco (exceção)
 			ofNullable(filtro.getId())

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -1827,39 +1827,6 @@ public class CpDao extends ModeloDao {
 	}
 
 	
-	public List<DpPessoa> consultaPessoasPorLotacao(final DpLotacao lotacao, boolean selecionarApenasAtivos) {
-		final JPAQuery<DpPessoa> query = new JPAQuery<DpPessoa>(em())
-				.from(qDpPessoa);
-						
-		final BooleanBuilder predicates;
-		if (selecionarApenasAtivos) {
-			predicates = new BooleanBuilder(qDpPessoa.lotacao.idLotacao.eq(lotacao.getId()));
-			predicates.and(qDpPessoa.dataFimPessoa.isNull());
-		} else {
-			final QDpPessoa subqDpPessoa = new QDpPessoa("subqDpPessoa");
-			final JPQLQuery<Long> subqueryPessoas = JPAExpressions
-					.select(subqDpPessoa.idPessoa.max())
-					.from(subqDpPessoa)
-					.where(subqDpPessoa.lotacao.idLotacao.eq(lotacao.getId()))
-					.groupBy(subqDpPessoa.idPessoaIni);
-			
-			final QDpPessoa subq2DpPessoa = new QDpPessoa("subq2DpPessoa");
-			final JPQLQuery<Long> subquery = JPAExpressions
-					.selectDistinct(subq2DpPessoa.idPessoaIni)
-					.from(subq2DpPessoa)
-					.where(subq2DpPessoa.dataFimPessoa.isNull());
-					
-			BooleanBuilder subpredicate = new BooleanBuilder(subq2DpPessoa.lotacao.idLotacao.ne(lotacao.getId()));
-			subpredicate.and(subq2DpPessoa.idPessoaIni.in(subqueryPessoas));
-			JPQLQuery<Long> subqueryPessoasRealocadas = subquery.where(subpredicate);
-			
-			predicates = new BooleanBuilder(qDpPessoa.idPessoa.in(subqueryPessoas));
-			predicates.and(qDpPessoa.idPessoa.notIn(subqueryPessoasRealocadas));
-		}
-		
-		return query.where(predicates).fetch();
-	}
-	
 	/*
 	 * @SuppressWarnings("unchecked") public Usuario
 	 * consultaUsuarioCadastrante(final String nmUsuario) { try { final Query


### PR DESCRIPTION
Related to PR #345.

Por motivos de histórico, usuários que foram realocados, aparecem como inativos na lotação original. Por exemplo, se um usuário `u`  saiu da lotação A para lotação B, ele foi inativado na lotaçao A e ativado na lotaçao B.  Ao editar a lotação A, é preciso desconsiderar usuários na situação do usuário `u`.  

Esta PR ataca este problema ao sempre considerar identidades ativas tanto na listagem de usuários quanto na edição de lotação..