### PR TITLE
Correção bloqueio de visível para tramitação

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -1514,8 +1514,7 @@ public class CpDao extends ModeloDao {
 				if (!identidadePrincipal.getCpOrgaoUsuario().getId().equals(filtro.getIdOrgaoUsu())) {
 					predicates.and(
 							qDpPessoa.orgaoUsuario.codOrgaoUsu.eq(identidadePrincipal.getCpOrgaoUsuario().getId())
-								.or(qDpPessoa.lotacao.unidadeReceptora.isTrue().and(qDpPessoa.visivelTramitacao.isTrue()))
-								.or(qDpPessoa.lotacao.unidadeReceptora.isFalse().and(qDpPessoa.visivelTramitacao.isTrue()))
+								.or(qDpPessoa.lotacao.unidadeReceptora.isTrue())
 					);						
 				} 
 			}
@@ -1534,9 +1533,9 @@ public class CpDao extends ModeloDao {
 					.ifPresent(predicates::and);
 		}
 		
-//		if (filtro.isBuscarApenasUsuariosVisiveisParaTramitacao()) {
-//			predicates.and(qDpPessoa.visivelTramitacao.isTrue());
-//		}
+		if (filtro.isBuscarApenasUsuariosVisiveisParaTramitacao()) {
+			predicates.and(qDpPessoa.visivelTramitacao.isTrue());
+		}
 
 		this.preencherPredicadosQueryConsultaPorFiltro(filtro, predicates);
 

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -1514,7 +1514,8 @@ public class CpDao extends ModeloDao {
 				if (!identidadePrincipal.getCpOrgaoUsuario().getId().equals(filtro.getIdOrgaoUsu())) {
 					predicates.and(
 							qDpPessoa.orgaoUsuario.codOrgaoUsu.eq(identidadePrincipal.getCpOrgaoUsuario().getId())
-								.or(qDpPessoa.lotacao.unidadeReceptora.isTrue())
+								.or(qDpPessoa.lotacao.unidadeReceptora.isTrue().and(qDpPessoa.visivelTramitacao.isTrue()))
+								.or(qDpPessoa.lotacao.unidadeReceptora.isFalse().and(qDpPessoa.visivelTramitacao.isTrue()))
 					);						
 				} 
 			}
@@ -1533,9 +1534,9 @@ public class CpDao extends ModeloDao {
 					.ifPresent(predicates::and);
 		}
 		
-		if (filtro.isBuscarApenasUsuariosVisiveisParaTramitacao()) {
-			predicates.and(qDpPessoa.visivelTramitacao.isTrue());
-		}
+//		if (filtro.isBuscarApenasUsuariosVisiveisParaTramitacao()) {
+//			predicates.and(qDpPessoa.visivelTramitacao.isTrue());
+//		}
 
 		this.preencherPredicadosQueryConsultaPorFiltro(filtro, predicates);
 

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -1514,7 +1514,7 @@ public class CpDao extends ModeloDao {
 				if (!identidadePrincipal.getCpOrgaoUsuario().getId().equals(filtro.getIdOrgaoUsu())) {
 					predicates.and(
 							qDpPessoa.orgaoUsuario.codOrgaoUsu.eq(identidadePrincipal.getCpOrgaoUsuario().getId())
-								.or(qDpPessoa.lotacao.unidadeReceptora.isTrue())
+							.or(qDpPessoa.lotacao.unidadeReceptora.isTrue().and(qDpPessoa.visivelTramitacao.isTrue()))
 					);						
 				} 
 			}
@@ -1533,9 +1533,9 @@ public class CpDao extends ModeloDao {
 					.ifPresent(predicates::and);
 		}
 		
-		if (filtro.isBuscarApenasUsuariosVisiveisParaTramitacao()) {
-			predicates.and(qDpPessoa.visivelTramitacao.isTrue());
-		}
+//		if (filtro.isBuscarApenasUsuariosVisiveisParaTramitacao()) {
+//			predicates.and(qDpPessoa.visivelTramitacao.isTrue());
+//		}
 
 		this.preencherPredicadosQueryConsultaPorFiltro(filtro, predicates);
 

--- a/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/dp/dao/CpDao.java
@@ -1532,10 +1532,6 @@ public class CpDao extends ModeloDao {
 					.map(qDpPessoa.situacaoFuncionalPessoa::eq)
 					.ifPresent(predicates::and);
 		}
-		
-//		if (filtro.isBuscarApenasUsuariosVisiveisParaTramitacao()) {
-//			predicates.and(qDpPessoa.visivelTramitacao.isTrue());
-//		}
 
 		this.preencherPredicadosQueryConsultaPorFiltro(filtro, predicates);
 

--- a/siga-vraptor-module/src/main/resources/META-INF/tags/selecao.tag
+++ b/siga-vraptor-module/src/main/resources/META-INF/tags/selecao.tag
@@ -39,10 +39,10 @@
 </c:if>
 
 <!-- A lista de par -->
-<c:forEach var="parametro" items="${fn:split(paramList,';')}">
+<c:forEach var="parametro" items="${fn:split(paramList,';')}" varStatus="stat">
 	<c:set var="p2" value="${fn:split(parametro,'=')}" />
 	<c:if test="${not empty p2 and not empty p2[0]}">
-		<c:set var="selecaoParams" value="${urlParams}&${p2[0]}=${p2[1]}" />
+		<c:set var="selecaoParams" value="${stat.first ? '' : selecaoParams}&${p2[0]}=${p2[1]}" />
 	</c:if>
 </c:forEach>
 

--- a/siga/src/main/webapp/WEB-INF/page/dpPessoa/buscar.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpPessoa/buscar.jsp
@@ -37,6 +37,7 @@ function sbmt(offset) {
 				<input type="hidden" name="buscarFechadas" value="${param['buscarFechadas']}" />
 				<input type="hidden" name="buscarSubstitutos" value="${param['buscarSubstitutos']}" />
 				<input type="hidden" name="buscarApenasUsuariosVisiveisParaTramitacao" value="${param['buscarApenasUsuariosVisiveisParaTramitacao']}" />
+				<input type="hidden" name="buscarApenasUsuariosDeUnidadesReceptoras" value="${param['buscarApenasUsuariosDeUnidadesReceptoras']}" />
 				<input type="hidden" name="modal" value="${param['modal']}" />
 				<div class="row">
 					<div class="col-sm">

--- a/sigaex/src/main/webapp/WEB-INF/page/exDocumento/edita.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exDocumento/edita.jsp
@@ -351,7 +351,7 @@
 								<c:when test='${exDocumentoDTO.tipoDestinatario == 1}'>
 									<input type="hidden" name="campos" value="destinatario" />
 									<label>&nbsp;&nbsp;&nbsp;</label>
-									<siga:selecao propriedade="destinatario" paramList="buscarApenasUsuariosVisiveisParaTramitacao=true;buscarApenasUsuariosDeUnidadesReceptoras=true;" inputName="exDocumentoDTO.destinatario" tema="simple" idAjax="destinatario1" reler="ajax" modulo="siga" />
+									<siga:selecao propriedade="destinatario" paramList="buscarApenasUsuariosVisiveisParaTramitacao=true;buscarApenasUsuariosDeUnidadesReceptoras=true" inputName="exDocumentoDTO.destinatario" tema="simple" idAjax="destinatario1" reler="ajax" modulo="siga" />
 										<!--  idAjax="destinatario"  -->
 								</c:when>
 								<c:when test='${exDocumentoDTO.tipoDestinatario == 2}'>

--- a/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferir.jsp
+++ b/sigaex/src/main/webapp/WEB-INF/page/exMovimentacao/aTransferir.jsp
@@ -139,7 +139,7 @@ $(function(){
 									<siga:selecao propriedade="lotaResponsavel" tema="simple" modulo="siga"/>
 								</c:when>
 								<c:when test="${tipoResponsavel == 2}">
-									<siga:selecao propriedade="responsavel" paramList="buscarApenasUsuariosVisiveisParaTramitacao=true;;buscarApenasUsuariosDeUnidadesReceptoras=true;" tema="simple" modulo="siga"/>
+									<siga:selecao propriedade="responsavel" paramList="buscarApenasUsuariosVisiveisParaTramitacao=true;buscarApenasUsuariosDeUnidadesReceptoras=true" tema="simple" modulo="siga"/>
 								</c:when>
 								<c:when test="${tipoResponsavel == 3}">
 									<siga:selecao propriedade="cpOrgao" tema="simple" modulo="siga"/>


### PR DESCRIPTION
Ocorria que o bloqueio era realizado mas pelo fato do usuário estar na unidade receptora ativa sempre estaria listado mesmo se fosse bloqueado para tramitação.