### PR TITLE
Correção de acesso aos módulos desprotegidos de permissão

### DIFF
--- a/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpServico.java
+++ b/siga-cp/src/main/java/br/gov/jfrj/siga/cp/CpServico.java
@@ -50,7 +50,14 @@ public class CpServico extends AbstractCpServico implements Selecionavel {
 	public static final long SERVICO_SIGA_EX = 2;
 	public static final long SERVICO_SIGA_WF = 3;
 	public static final long SERVICO_SIGA_SR = 4;
-	
+		
+	public static final String VERIFICADOR_ACESSO_CADASTRO_CONFIGURACOES = "FE:Ferramentas;CFG:Cadastrar Configurações";
+	public static final String VERIFICADOR_ACESSO_CADASTRO_PESSOA = "GI:Módulo de Gestão de Identidade;CAD_PESSOA:Cadastrar Pessoa";
+	public static final String VERIFICADOR_ACESSO_CADASTRO_LOTACAO = "GI:Módulo de Gestão de Identidade;CAD_LOTACAO:Cadastrar Lotação";
+	public static final String VERIFICADOR_ACESSO_CADASTRO_ORGAO_USUARIO = "GI:Módulo de Gestão de Identidade;CAD_ORGAO:Cadastrar Orgãos";
+	public static final String VERIFICADOR_ACESSO_CADASTRO_FUNCAO = "GI:Módulo de Gestão de Identidade;CAD_FUNCAO:Cadastrar Função de Confiança";
+	public static final String VERIFICADOR_ACESSO_CADASTRO_CARGO = "GI:Módulo de Gestão de Identidade;CAD_LOTACAO:Cadastrar Cargo";
+
 	
 	public static final String ACESSO_WEBSERVICE = "SPSEMPAPEL-SIGA-WS";
 	

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/ConfiguracaoController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/ConfiguracaoController.java
@@ -13,6 +13,7 @@ import br.com.caelum.vraptor.Result;
 import br.com.caelum.vraptor.view.Results;
 import br.gov.jfrj.siga.base.AplicacaoException;
 import br.gov.jfrj.siga.cp.CpConfiguracao;
+import br.gov.jfrj.siga.cp.CpServico;
 import br.gov.jfrj.siga.cp.CpTipoConfiguracao;
 import br.gov.jfrj.siga.cp.bl.Cp;
 import br.gov.jfrj.siga.cp.bl.CpConfiguracaoComparator;
@@ -20,7 +21,6 @@ import br.gov.jfrj.siga.cp.model.DpCargoSelecao;
 import br.gov.jfrj.siga.cp.model.DpFuncaoConfiancaSelecao;
 import br.gov.jfrj.siga.cp.model.DpLotacaoSelecao;
 import br.gov.jfrj.siga.cp.model.DpPessoaSelecao;
-import br.gov.jfrj.siga.cp.model.enm.CpParamCfg;
 import br.gov.jfrj.siga.cp.model.enm.CpTipoDeConfiguracao;
 import br.gov.jfrj.siga.cp.model.enm.ITipoDeConfiguracao;
 import br.gov.jfrj.siga.dp.CpOrgaoUsuario;
@@ -28,8 +28,6 @@ import br.gov.jfrj.siga.dp.dao.CpDao;
 
 @Controller
 public class ConfiguracaoController extends SigaController {
-
-	private static final String VERIFICADOR_ACESSO = "FE:Ferramentas;CFG:Cadastrar Configurações";
 
 	/**
 	 * @deprecated CDI eyes only
@@ -46,7 +44,7 @@ public class ConfiguracaoController extends SigaController {
 
 	@Get("app/configuracao/listar")
 	public void lista(Long idTpConfiguracao, Long idOrgaoUsu) throws Exception {
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_CONFIGURACOES);
 		if (idTpConfiguracao == null)
 			idTpConfiguracao = CpTipoDeConfiguracao.CADASTRAR_QUALQUER_SUBST.getId();
 		ITipoDeConfiguracao tpconf = CpTipoDeConfiguracao.getById(idTpConfiguracao);
@@ -59,7 +57,7 @@ public class ConfiguracaoController extends SigaController {
 	@Get("app/configuracao/listar_cadastradas")
 	public void listaCadastradas(Long idTpConfiguracao, Long idOrgaoUsu, Long idTpMov, Long idFormaDoc, Long idMod,
 			String nmTipoRetorno, boolean campoFixo) throws Exception {
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_CONFIGURACOES);;
 
 		CpConfiguracao config = new CpConfiguracao();
 
@@ -95,7 +93,7 @@ public class ConfiguracaoController extends SigaController {
 			DpFuncaoConfiancaSelecao funcaoSel, DpPessoaSelecao pessoaObjetoSel, DpLotacaoSelecao lotacaoObjetoSel,
 			DpCargoSelecao cargoObjetoSel, DpFuncaoConfiancaSelecao funcaoObjetoSel, Long idOrgaoObjeto,
 			Long idTpLotacao, String nmTipoRetorno, Long idDefinicaoDeProcedimento) throws Exception {
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_CONFIGURACOES);;
 		CpConfiguracao config = new CpConfiguracao();
 
 		if (id != null) {
@@ -128,7 +126,7 @@ public class ConfiguracaoController extends SigaController {
 	@Transacional
 	@Get("app/configuracao/excluir")
 	public void excluir(Long id, String nmTipoRetorno, Long idMod, Long idFormaDoc) throws Exception {
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_CONFIGURACOES);;
 
 		if (id != null) {
 			CpConfiguracao config = dao().consultar(id, CpConfiguracao.class, false);
@@ -150,7 +148,7 @@ public class ConfiguracaoController extends SigaController {
 			DpLotacaoSelecao lotacaoObjeto_lotacaoSel, DpCargoSelecao cargoObjeto_cargoSel,
 			DpFuncaoConfiancaSelecao funcaoObjeto_funcaoSel, Long idOrgaoObjeto, Long idTpLotacao, String nmTipoRetorno,
 			boolean campoFixo) throws Exception {
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_CONFIGURACOES);;
 		final CpConfiguracao config = new CpConfiguracaoBuilder(CpConfiguracao.class, dao).setId(id)
 				.setIdSituacao(idSituacao).setIdTpConfiguracao(idTpConfiguracao).setPessoaSel(pessoaSel)
 				.setLotacaoSel(lotacaoSel).setCargoSel(cargoSel).setFuncaoSel(funcaoSel).setIdOrgaoObjeto(idOrgaoObjeto)

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpCargoController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpCargoController.java
@@ -42,6 +42,8 @@ import br.gov.jfrj.siga.model.Selecionavel;
 public class DpCargoController extends
 		SigaSelecionavelControllerSupport<DpCargo, DpCargoDaoFiltro> {
 	
+	private static final String VERIFICADOR_ACESSO = "GI:Módulo de Gestão de Identidade;CAD_LOTACAO:Cadastrar Cargo";
+	
 	private Long orgaoUsu;
 
 
@@ -65,6 +67,9 @@ public class DpCargoController extends
 	@Post
 	@Path({"/app/cargo/buscar","/cargo/buscar.action"})
 	public void busca(String nome, Long idOrgaoUsu, Integer paramoffset, String postback) throws Exception{
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		if (postback == null)
 			orgaoUsu = getLotaTitular().getOrgaoUsuario().getIdOrgaoUsu();
 		else
@@ -120,6 +125,9 @@ public class DpCargoController extends
 	@Post
 	@Path({"/app/cargo/selecionar","/cargo/selecionar.action"})
 	public void selecionar(String sigla) {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		this.setNome(sigla);
 		String resultado =  super.aSelecionar(sigla);
 		
@@ -133,6 +141,8 @@ public class DpCargoController extends
 	
 	@Get("app/cargo/listar")
 	public void lista(Integer paramoffset, Long idOrgaoUsu, String nome) throws Exception {		
+		
+		assertAcesso(VERIFICADOR_ACESSO);
 		
 		if(CpConfiguracaoBL.SIGLAS_ORGAOS_ADMINISTRADORES.contains(getTitular().getOrgaoUsuario().getSigla())) {
 			result.include("orgaosUsu", dao().listarOrgaosUsuarios());
@@ -166,7 +176,9 @@ public class DpCargoController extends
 	@Post
 	@Path("app/cargo/exportarCsv")
 	public Download exportarCsv(Long idOrgaoUsu, String nome) throws Exception {				
-			
+
+		assertAcesso(VERIFICADOR_ACESSO);
+		
  		if(idOrgaoUsu != null) {
 			DpCargoDaoFiltro dpCargo = new DpCargoDaoFiltro(nome, idOrgaoUsu);																
 															
@@ -209,6 +221,9 @@ public class DpCargoController extends
 	
 	@Get("/app/cargo/editar")
 	public void edita(final Long id){
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		if (id != null) {
 			DpCargo cargo = dao().consultar(id, DpCargo.class, false);
 			result.include("nmCargo",cargo.getNomeCargo());
@@ -238,6 +253,7 @@ public class DpCargoController extends
 	public void editarGravar(final Long id, 
 							 final String nmCargo, 
 							 final Long idOrgaoUsu) throws Exception{
+		
 		assertAcesso("GI:Módulo de Gestão de Identidade;CAD_CARGO: Cadastrar Cargo");
 		
 		if(nmCargo == null)
@@ -301,6 +317,9 @@ public class DpCargoController extends
 
 	@Get("/app/cargo/carregarExcel")
 	public void carregarExcel() {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		if(CpConfiguracaoBL.SIGLAS_ORGAOS_ADMINISTRADORES.contains(getTitular().getOrgaoUsuario().getSigla())) {
 			result.include("orgaosUsu", dao().listarOrgaosUsuarios());
 		} else {
@@ -313,6 +332,9 @@ public class DpCargoController extends
 	@Transacional
 	@Post("/app/cargo/carga")
 	public Download carga( final UploadedFile arquivo, Long idOrgaoUsu) throws Exception {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		InputStream inputStream = null;
 		try {
 			String nomeArquivo = arquivo.getFileName();

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpCargoController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpCargoController.java
@@ -1,7 +1,6 @@
 package br.gov.jfrj.siga.vraptor;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -13,8 +12,6 @@ import java.util.UUID;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.servlet.http.HttpServletRequest;
-
-import org.apache.commons.io.FileUtils;
 
 import br.com.caelum.vraptor.Controller;
 import br.com.caelum.vraptor.Get;
@@ -28,6 +25,7 @@ import br.com.caelum.vraptor.view.Results;
 import br.gov.jfrj.siga.base.AplicacaoException;
 import br.gov.jfrj.siga.base.SigaModal;
 import br.gov.jfrj.siga.base.util.Texto;
+import br.gov.jfrj.siga.cp.CpServico;
 import br.gov.jfrj.siga.cp.bl.Cp;
 import br.gov.jfrj.siga.cp.bl.CpBL;
 import br.gov.jfrj.siga.cp.bl.CpConfiguracaoBL;
@@ -41,8 +39,6 @@ import br.gov.jfrj.siga.model.Selecionavel;
 @Controller
 public class DpCargoController extends
 		SigaSelecionavelControllerSupport<DpCargo, DpCargoDaoFiltro> {
-	
-	private static final String VERIFICADOR_ACESSO = "GI:Módulo de Gestão de Identidade;CAD_LOTACAO:Cadastrar Cargo";
 	
 	private Long orgaoUsu;
 
@@ -68,7 +64,7 @@ public class DpCargoController extends
 	@Path({"/app/cargo/buscar","/cargo/buscar.action"})
 	public void busca(String nome, Long idOrgaoUsu, Integer paramoffset, String postback) throws Exception{
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_CARGO);
 		
 		if (postback == null)
 			orgaoUsu = getLotaTitular().getOrgaoUsuario().getIdOrgaoUsu();
@@ -126,7 +122,7 @@ public class DpCargoController extends
 	@Path({"/app/cargo/selecionar","/cargo/selecionar.action"})
 	public void selecionar(String sigla) {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_CARGO);
 		
 		this.setNome(sigla);
 		String resultado =  super.aSelecionar(sigla);
@@ -142,7 +138,7 @@ public class DpCargoController extends
 	@Get("app/cargo/listar")
 	public void lista(Integer paramoffset, Long idOrgaoUsu, String nome) throws Exception {		
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_CARGO);
 		
 		if(CpConfiguracaoBL.SIGLAS_ORGAOS_ADMINISTRADORES.contains(getTitular().getOrgaoUsuario().getSigla())) {
 			result.include("orgaosUsu", dao().listarOrgaosUsuarios());
@@ -177,7 +173,7 @@ public class DpCargoController extends
 	@Path("app/cargo/exportarCsv")
 	public Download exportarCsv(Long idOrgaoUsu, String nome) throws Exception {				
 
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_CARGO);
 		
  		if(idOrgaoUsu != null) {
 			DpCargoDaoFiltro dpCargo = new DpCargoDaoFiltro(nome, idOrgaoUsu);																
@@ -222,7 +218,7 @@ public class DpCargoController extends
 	@Get("/app/cargo/editar")
 	public void edita(final Long id){
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_CARGO);
 		
 		if (id != null) {
 			DpCargo cargo = dao().consultar(id, DpCargo.class, false);
@@ -318,7 +314,7 @@ public class DpCargoController extends
 	@Get("/app/cargo/carregarExcel")
 	public void carregarExcel() {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_CARGO);
 		
 		if(CpConfiguracaoBL.SIGLAS_ORGAOS_ADMINISTRADORES.contains(getTitular().getOrgaoUsuario().getSigla())) {
 			result.include("orgaosUsu", dao().listarOrgaosUsuarios());
@@ -333,7 +329,7 @@ public class DpCargoController extends
 	@Post("/app/cargo/carga")
 	public Download carga( final UploadedFile arquivo, Long idOrgaoUsu) throws Exception {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_CARGO);
 		
 		InputStream inputStream = null;
 		try {

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpFuncaoController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpFuncaoController.java
@@ -25,6 +25,7 @@ import br.com.caelum.vraptor.view.Results;
 import br.gov.jfrj.siga.base.AplicacaoException;
 import br.gov.jfrj.siga.base.SigaModal;
 import br.gov.jfrj.siga.base.util.Texto;
+import br.gov.jfrj.siga.cp.CpServico;
 import br.gov.jfrj.siga.cp.bl.Cp;
 import br.gov.jfrj.siga.cp.bl.CpBL;
 import br.gov.jfrj.siga.cp.bl.CpConfiguracaoBL;
@@ -38,11 +39,8 @@ import br.gov.jfrj.siga.model.Selecionavel;
 @Controller
 public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFuncaoConfianca, DpFuncaoConfiancaDaoFiltro>{
 
-	private static final String VERIFICADOR_ACESSO = "GI:Módulo de Gestão de Identidade;CAD_FUNCAO:Cadastrar Função de Confiança";
-	
 	private Long orgaoUsu;
 	
-
 	/**
 	 * @deprecated CDI eyes only
 	 */
@@ -91,7 +89,7 @@ public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFunc
 	@Path({"/app/funcao/buscar", "/funcao/buscar.action"})
 	public void buscar(String nome, String postback, Integer paramoffset, Long idOrgaoUsu) throws Exception {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_FUNCAO);
 		
 		if (postback == null){
 			orgaoUsu = getLotaTitular().getOrgaoUsuario().getIdOrgaoUsu();
@@ -126,7 +124,7 @@ public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFunc
 	@Get("app/funcao/listar")
 	public void lista(Integer paramoffset, Long idOrgaoUsu, String nome) throws Exception {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_FUNCAO);
 		
 		if(CpConfiguracaoBL.SIGLAS_ORGAOS_ADMINISTRADORES.contains(getTitular().getOrgaoUsuario().getSigla())) {
 			result.include("orgaosUsu", dao().listarOrgaosUsuarios());
@@ -161,7 +159,7 @@ public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFunc
 	@Path("app/funcao/exportarCsv")
 	public Download exportarCsv(Long idOrgaoUsu, String nome) throws Exception {				
 			
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_FUNCAO);
 		
  		if(idOrgaoUsu != null) {
  			DpFuncaoConfiancaDaoFiltro dpFuncao = new DpFuncaoConfiancaDaoFiltro(nome, idOrgaoUsu);																
@@ -206,7 +204,7 @@ public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFunc
 	@Get("/app/funcao/editar")
 	public void edita(final Long id){
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_FUNCAO);
 		
 		if (id != null) {
 			DpFuncaoConfianca funcao = dao().consultar(id, DpFuncaoConfianca.class, false);
@@ -239,7 +237,7 @@ public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFunc
 							 final String nmFuncao, 
 							 final Long idOrgaoUsu) throws Exception{
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_FUNCAO);
 		
 		if(nmFuncao == null)
 			throw new AplicacaoException("Nome da função não informado");
@@ -306,7 +304,7 @@ public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFunc
 	@Get("/app/funcao/carregarExcel")
 	public void carregarExcel() {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_FUNCAO);
 		
 		if(CpConfiguracaoBL.SIGLAS_ORGAOS_ADMINISTRADORES.contains(getTitular().getOrgaoUsuario().getSigla())) {
 			result.include("orgaosUsu", dao().listarOrgaosUsuarios());
@@ -321,7 +319,7 @@ public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFunc
 	@Post("/app/funcao/carga")
 	public Download carga( final UploadedFile arquivo, Long idOrgaoUsu) throws Exception {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_FUNCAO);
 		
 		InputStream inputStream = null;
 		try {

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpFuncaoController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpFuncaoController.java
@@ -38,6 +38,8 @@ import br.gov.jfrj.siga.model.Selecionavel;
 @Controller
 public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFuncaoConfianca, DpFuncaoConfiancaDaoFiltro>{
 
+	private static final String VERIFICADOR_ACESSO = "GI:Módulo de Gestão de Identidade;CAD_FUNCAO:Cadastrar Função de Confiança";
+	
 	private Long orgaoUsu;
 	
 
@@ -88,6 +90,9 @@ public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFunc
 	@Post
 	@Path({"/app/funcao/buscar", "/funcao/buscar.action"})
 	public void buscar(String nome, String postback, Integer paramoffset, Long idOrgaoUsu) throws Exception {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		if (postback == null){
 			orgaoUsu = getLotaTitular().getOrgaoUsuario().getIdOrgaoUsu();
 		}else{
@@ -120,6 +125,9 @@ public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFunc
 	
 	@Get("app/funcao/listar")
 	public void lista(Integer paramoffset, Long idOrgaoUsu, String nome) throws Exception {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		if(CpConfiguracaoBL.SIGLAS_ORGAOS_ADMINISTRADORES.contains(getTitular().getOrgaoUsuario().getSigla())) {
 			result.include("orgaosUsu", dao().listarOrgaosUsuarios());
 		} else {
@@ -153,6 +161,8 @@ public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFunc
 	@Path("app/funcao/exportarCsv")
 	public Download exportarCsv(Long idOrgaoUsu, String nome) throws Exception {				
 			
+		assertAcesso(VERIFICADOR_ACESSO);
+		
  		if(idOrgaoUsu != null) {
  			DpFuncaoConfiancaDaoFiltro dpFuncao = new DpFuncaoConfiancaDaoFiltro(nome, idOrgaoUsu);																
 															
@@ -195,6 +205,9 @@ public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFunc
 	
 	@Get("/app/funcao/editar")
 	public void edita(final Long id){
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		if (id != null) {
 			DpFuncaoConfianca funcao = dao().consultar(id, DpFuncaoConfianca.class, false);
 			result.include("nmFuncao",funcao.getDescricao());
@@ -225,7 +238,8 @@ public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFunc
 	public void editarGravar(final Long id, 
 							 final String nmFuncao, 
 							 final Long idOrgaoUsu) throws Exception{
-		assertAcesso("GI:Módulo de Gestão de Identidade;CAD_FUNCAO:Cadastrar Função de Confiança");
+		
+		assertAcesso(VERIFICADOR_ACESSO);
 		
 		if(nmFuncao == null)
 			throw new AplicacaoException("Nome da função não informado");
@@ -291,6 +305,9 @@ public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFunc
 	
 	@Get("/app/funcao/carregarExcel")
 	public void carregarExcel() {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		if(CpConfiguracaoBL.SIGLAS_ORGAOS_ADMINISTRADORES.contains(getTitular().getOrgaoUsuario().getSigla())) {
 			result.include("orgaosUsu", dao().listarOrgaosUsuarios());
 		} else {
@@ -303,6 +320,9 @@ public class DpFuncaoController extends SigaSelecionavelControllerSupport<DpFunc
 	@Transacional
 	@Post("/app/funcao/carga")
 	public Download carga( final UploadedFile arquivo, Long idOrgaoUsu) throws Exception {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		InputStream inputStream = null;
 		try {
 			String nomeArquivo = arquivo.getFileName();

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
@@ -6,14 +6,14 @@ import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.UUID;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -33,6 +33,7 @@ import br.gov.jfrj.siga.base.Prop;
 import br.gov.jfrj.siga.base.SigaMessages;
 import br.gov.jfrj.siga.base.SigaModal;
 import br.gov.jfrj.siga.base.util.Texto;
+import br.gov.jfrj.siga.cp.CpServico;
 import br.gov.jfrj.siga.cp.bl.Cp;
 import br.gov.jfrj.siga.cp.bl.CpBL;
 import br.gov.jfrj.siga.cp.bl.CpConfiguracaoBL;
@@ -47,8 +48,6 @@ import br.gov.jfrj.siga.model.Selecionavel;
 
 @Controller
 public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLotacao, DpLotacaoDaoFiltro> {
-
-	private static final String VERIFICADOR_ACESSO = "GI:Módulo de Gestão de Identidade;CAD_LOTACAO:Cadastrar Lotação";
 	
 	private Long orgaoUsu;
 	
@@ -105,7 +104,7 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Path({ "/app/lotacao/buscar", "/lotacao/buscar.action" })
 	public void busca(String propriedade, String sigla, Long idOrgaoUsu, Integer paramoffset, String postback, final String primeiraVez) throws Exception {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_LOTACAO);
 		
 		this.orgaoUsu = idOrgaoUsu;
 		if (equalsIgnoreCase("lotacaoDestinatario", propriedade)) {
@@ -228,7 +227,7 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Get("app/lotacao/listar")
 	public void lista(Integer paramoffset, Long idOrgaoUsu, String nome) throws Exception {
 
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_LOTACAO);
 		
 		if (CpConfiguracaoBL.SIGLAS_ORGAOS_ADMINISTRADORES.contains(getTitular().getOrgaoUsuario().getSigla())) {
 			result.include("orgaosUsu", dao().listarOrgaosUsuarios());
@@ -265,7 +264,7 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Path("app/lotacao/exportarCsv")
 	public Download exportarCsv(Long idOrgaoUsu, String nome) throws Exception {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_LOTACAO);
 
 		if (idOrgaoUsu != null) {
 			DpLotacaoDaoFiltro dpLotacao = new DpLotacaoDaoFiltro(nome, idOrgaoUsu);
@@ -328,7 +327,7 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Get("/app/lotacao/listaLocalidades")
 	public void listaLocalidades(Integer idUf) {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_LOTACAO);
 		
 		CpUF uf = new CpUF();
 		uf.setIdUF(Long.valueOf(idUf));
@@ -338,7 +337,7 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Get("/app/lotacao/editar")
 	public void edita(final Long id){
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_LOTACAO);
 		
 		Long idUf = null;
 
@@ -395,7 +394,7 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 			final Boolean isExternaLotacao, final Long lotacaoPai, final Long idLocalidade, final boolean unidadeReceptora)
 			throws Exception {
 
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_LOTACAO);
 
 		DpLotacao lotacaoFoiCriada = Cp.getInstance().getBL().criarLotacao(getIdentidadeCadastrante(), getTitular(), getTitular().getLotacao(), id,
 				nmLotacao, idOrgaoUsu, siglaLotacao, isExternaLotacao, lotacaoPai, idLocalidade, unidadeReceptora);
@@ -413,7 +412,7 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Post("/app/lotacao/ativarInativar")
 	public void ativarInativar(final Long id) throws Exception {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_LOTACAO);
 		
 		DpLotacao lotacao = dao().consultar(id, DpLotacao.class, false);
 
@@ -454,7 +453,7 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Post("/app/lotacao/suspender")
 	public void suspender(final Long id) throws Exception {
 
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_LOTACAO);
 		
 		DpLotacao lotacao = dao().consultar(id, DpLotacao.class, false);
 		DpLotacao lotacaoNova = new DpLotacao();
@@ -505,7 +504,7 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Get("/app/lotacao/carregarExcel")
 	public void carregarExcel() {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_LOTACAO);
 		
 		if (CpConfiguracaoBL.SIGLAS_ORGAOS_ADMINISTRADORES.contains(getTitular().getOrgaoUsuario().getSigla())) {
 			result.include("orgaosUsu", dao().listarOrgaosUsuarios());
@@ -520,7 +519,7 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Post("/app/lotacao/carga")
 	public Download carga(final UploadedFile arquivo, Long idOrgaoUsu) throws Exception {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_LOTACAO);
 		
 		InputStream inputStream = null;
 		try {

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpLotacaoController.java
@@ -48,6 +48,8 @@ import br.gov.jfrj.siga.model.Selecionavel;
 @Controller
 public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLotacao, DpLotacaoDaoFiltro> {
 
+	private static final String VERIFICADOR_ACESSO = "GI:Módulo de Gestão de Identidade;CAD_LOTACAO:Cadastrar Lotação";
+	
 	private Long orgaoUsu;
 	
 	/**
@@ -102,6 +104,9 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Post
 	@Path({ "/app/lotacao/buscar", "/lotacao/buscar.action" })
 	public void busca(String propriedade, String sigla, Long idOrgaoUsu, Integer paramoffset, String postback, final String primeiraVez) throws Exception {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		this.orgaoUsu = idOrgaoUsu;
 		if (equalsIgnoreCase("lotacaoDestinatario", propriedade)) {
 			if (primeiraVez != null || !getTitular().isTramitarOutrosOrgaos()) {
@@ -223,6 +228,8 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Get("app/lotacao/listar")
 	public void lista(Integer paramoffset, Long idOrgaoUsu, String nome) throws Exception {
 
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		if (CpConfiguracaoBL.SIGLAS_ORGAOS_ADMINISTRADORES.contains(getTitular().getOrgaoUsuario().getSigla())) {
 			result.include("orgaosUsu", dao().listarOrgaosUsuarios());
 		} else {
@@ -257,6 +264,8 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Post
 	@Path("app/lotacao/exportarCsv")
 	public Download exportarCsv(Long idOrgaoUsu, String nome) throws Exception {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
 
 		if (idOrgaoUsu != null) {
 			DpLotacaoDaoFiltro dpLotacao = new DpLotacaoDaoFiltro(nome, idOrgaoUsu);
@@ -318,6 +327,9 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	
 	@Get("/app/lotacao/listaLocalidades")
 	public void listaLocalidades(Integer idUf) {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		CpUF uf = new CpUF();
 		uf.setIdUF(Long.valueOf(idUf));
 		result.include("listaLocalidades", dao().consultarLocalidadesPorUF(uf));
@@ -325,6 +337,9 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	
 	@Get("/app/lotacao/editar")
 	public void edita(final Long id){
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		Long idUf = null;
 
 		List<DpLotacao> listaLotacaoPai = new ArrayList<DpLotacao>();
@@ -380,7 +395,7 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 			final Boolean isExternaLotacao, final Long lotacaoPai, final Long idLocalidade, final boolean unidadeReceptora)
 			throws Exception {
 
-		assertAcesso("GI:Módulo de Gestão de Identidade;CAD_LOTACAO: Cadastrar Lotação");
+		assertAcesso(VERIFICADOR_ACESSO);
 
 		DpLotacao lotacaoFoiCriada = Cp.getInstance().getBL().criarLotacao(getIdentidadeCadastrante(), getTitular(), getTitular().getLotacao(), id,
 				nmLotacao, idOrgaoUsu, siglaLotacao, isExternaLotacao, lotacaoPai, idLocalidade, unidadeReceptora);
@@ -397,6 +412,9 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Transacional
 	@Post("/app/lotacao/ativarInativar")
 	public void ativarInativar(final Long id) throws Exception {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		DpLotacao lotacao = dao().consultar(id, DpLotacao.class, false);
 
 		// ativar
@@ -436,6 +454,8 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Post("/app/lotacao/suspender")
 	public void suspender(final Long id) throws Exception {
 
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		DpLotacao lotacao = dao().consultar(id, DpLotacao.class, false);
 		DpLotacao lotacaoNova = new DpLotacao();
 		DpLotacao lotacaoFilhoNova = new DpLotacao();
@@ -484,6 +504,9 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 
 	@Get("/app/lotacao/carregarExcel")
 	public void carregarExcel() {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		if (CpConfiguracaoBL.SIGLAS_ORGAOS_ADMINISTRADORES.contains(getTitular().getOrgaoUsuario().getSigla())) {
 			result.include("orgaosUsu", dao().listarOrgaosUsuarios());
 		} else {
@@ -496,6 +519,9 @@ public class DpLotacaoController extends SigaSelecionavelControllerSupport<DpLot
 	@Transacional
 	@Post("/app/lotacao/carga")
 	public Download carga(final UploadedFile arquivo, Long idOrgaoUsu) throws Exception {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		InputStream inputStream = null;
 		try {
 			String nomeArquivo = arquivo.getFileName();

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
@@ -91,6 +91,8 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 
 	private static final Logger log = Logger.getLogger(DpPessoaController.class);
 	
+	private static final String VERIFICADOR_ACESSO = "GI:Módulo de Gestão de Identidade;CAD_PESSOA:Cadastrar Pessoa";
+	
 	private Long orgaoUsu;
 	private DpLotacaoSelecao lotacaoSel;
 	private boolean semLimiteOrgaoOrigem = true;
@@ -245,6 +247,8 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	public void lista(Integer paramoffset, Long idOrgaoUsu, String nome, String cpfPesquisa, Long idCargoPesquisa, Long idFuncaoPesquisa, Long idLotacaoPesquisa, String emailPesquisa, String identidadePesquisa,
 			boolean buscarInativos) throws Exception {
 
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		result.include("request",getRequest());
 		List<CpOrgaoUsuario> list = new ArrayList<CpOrgaoUsuario>();
 		CpOrgaoUsuario ou = new CpOrgaoUsuario();
@@ -320,6 +324,9 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	@Transacional
 	@Get("/app/pessoa/ativarInativar")
 	public void ativarInativar(final Long id, Integer offset, Long idOrgaoUsu, String nome, String cpfPesquisa, Long idCargoPesquisa, Long idFuncaoPesquisa, Long idLotacaoPesquisa, String emailPesquisa, String identidadePesquisa) throws Exception{
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		CpOrgaoUsuario ou = new CpOrgaoUsuario();
 		DpPessoa pessoaAnt = dao().consultar(id, DpPessoa.class, false).getPessoaAtual();
 		ou.setIdOrgaoUsu(pessoaAnt.getOrgaoUsuario().getId());
@@ -404,6 +411,9 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 
 	@Get("/app/pessoa/editar")
 	public void edita(final Long id) {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		CpOrgaoUsuario ou = new CpOrgaoUsuario();
 		
 		/*Carrega lista UF*/
@@ -623,7 +633,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 			final String dataExpedicaoIdentidade, final String nomeExibicao, final String enviarEmail,
 			final Boolean tramitarOutrosOrgaos, final Boolean isUsuarioVisivelTramitacao) throws Exception {
 
-		assertAcesso("GI:Módulo de Gestão de Identidade;CAD_PESSOA:Cadastrar Pessoa");
+		assertAcesso(VERIFICADOR_ACESSO);
 
 		try {
 			DpPessoa pes = new CpBL().criarUsuario(id, getIdentidadeCadastrante(), idOrgaoUsu, idCargo, idFuncao,
@@ -672,6 +682,9 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 
 	@Get("/app/pessoa/carregarExcel")
 	public void carregarExcel() {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		if (CpConfiguracaoBL.SIGLAS_ORGAOS_ADMINISTRADORES.contains(getTitular().getOrgaoUsuario().getSigla())) {
 			result.include("orgaosUsu", dao().listarOrgaosUsuarios());
 		} else {
@@ -684,6 +697,9 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	@Transacional
 	@Post("/app/pessoa/carga")
 	public Download carga(final UploadedFile arquivo, Long idOrgaoUsu) throws Exception {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		InputStream inputStream = null;
 		try {
 			String nomeArquivo = arquivo.getFileName();
@@ -716,7 +732,10 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	
 	@Consumes("application/json")
 	@Post("/app/pessoa/usuarios/envioDeEmailPendente")
-	public void buscarUsuariosComEnvioDeEmailPendente(DpPessoaUsuarioDTO dados) {								
+	public void buscarUsuariosComEnvioDeEmailPendente(DpPessoaUsuarioDTO dados) {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		DpPessoaDaoFiltro dpPessoa = new DpPessoaDaoFiltro();
 		
 		dpPessoa.setIdOrgaoUsu(dados.getIdOrgaoUsu());		
@@ -732,6 +751,9 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	@Path({"app/pessoa/enviarEmail", "/pessoa/enviarEmail.action"})
 	public void enviaEmail(Integer paramoffset, Long idOrgaoUsu, String nome, String cpfPesquisa,
 			String idLotacaoPesquisa, String idUsuarioPesquisa, Integer paramTamanho) throws Exception {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		result.include("request", getRequest());
 		List<CpOrgaoUsuario> list = new ArrayList<CpOrgaoUsuario>();
 		CpOrgaoUsuario ou = new CpOrgaoUsuario();
@@ -789,6 +811,9 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	@Transacional
 	@Post("app/pessoa/enviar")
 	public void enviar(Long idOrgaoUsu, String nome, String cpfPesquisa, String idLotacaoPesquisa, String idUsuarioPesquisa) throws Exception {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		String[] senhaGerada = new String[1];
 
 		if (idOrgaoUsu == null || idOrgaoUsu == 0)
@@ -823,6 +848,8 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	@Path("app/pessoa/exportarCsv")
 	public Download exportarCsv(Long idOrgaoUsu, String nome, String cpfPesquisa, Long idCargoPesquisa,
 			Long idFuncaoPesquisa, Long idLotacaoPesquisa, String emailPesquisa, String identidadePesquisa) throws IOException {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
 
 		CpOrgaoUsuario ou = new CpOrgaoUsuario();
 

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/DpPessoaController.java
@@ -34,7 +34,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Date;
@@ -68,6 +67,7 @@ import br.gov.jfrj.siga.base.SigaMessages;
 import br.gov.jfrj.siga.base.SigaModal;
 import br.gov.jfrj.siga.base.util.Texto;
 import br.gov.jfrj.siga.cp.CpIdentidade;
+import br.gov.jfrj.siga.cp.CpServico;
 import br.gov.jfrj.siga.cp.bl.Cp;
 import br.gov.jfrj.siga.cp.bl.CpBL;
 import br.gov.jfrj.siga.cp.bl.CpConfiguracaoBL;
@@ -90,8 +90,6 @@ import br.gov.jfrj.siga.model.Selecionavel;
 public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPessoa, DpPessoaDaoFiltro> {
 
 	private static final Logger log = Logger.getLogger(DpPessoaController.class);
-	
-	private static final String VERIFICADOR_ACESSO = "GI:Módulo de Gestão de Identidade;CAD_PESSOA:Cadastrar Pessoa";
 	
 	private Long orgaoUsu;
 	private DpLotacaoSelecao lotacaoSel;
@@ -247,7 +245,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	public void lista(Integer paramoffset, Long idOrgaoUsu, String nome, String cpfPesquisa, Long idCargoPesquisa, Long idFuncaoPesquisa, Long idLotacaoPesquisa, String emailPesquisa, String identidadePesquisa,
 			boolean buscarInativos) throws Exception {
 
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_PESSOA);;
 		
 		result.include("request",getRequest());
 		List<CpOrgaoUsuario> list = new ArrayList<CpOrgaoUsuario>();
@@ -325,7 +323,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	@Get("/app/pessoa/ativarInativar")
 	public void ativarInativar(final Long id, Integer offset, Long idOrgaoUsu, String nome, String cpfPesquisa, Long idCargoPesquisa, Long idFuncaoPesquisa, Long idLotacaoPesquisa, String emailPesquisa, String identidadePesquisa) throws Exception{
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_PESSOA);;
 		
 		CpOrgaoUsuario ou = new CpOrgaoUsuario();
 		DpPessoa pessoaAnt = dao().consultar(id, DpPessoa.class, false).getPessoaAtual();
@@ -412,7 +410,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	@Get("/app/pessoa/editar")
 	public void edita(final Long id) {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_PESSOA);;
 		
 		CpOrgaoUsuario ou = new CpOrgaoUsuario();
 		
@@ -633,7 +631,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 			final String dataExpedicaoIdentidade, final String nomeExibicao, final String enviarEmail,
 			final Boolean tramitarOutrosOrgaos, final Boolean isUsuarioVisivelTramitacao) throws Exception {
 
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_PESSOA);;
 
 		try {
 			DpPessoa pes = new CpBL().criarUsuario(id, getIdentidadeCadastrante(), idOrgaoUsu, idCargo, idFuncao,
@@ -683,7 +681,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	@Get("/app/pessoa/carregarExcel")
 	public void carregarExcel() {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_PESSOA);;
 		
 		if (CpConfiguracaoBL.SIGLAS_ORGAOS_ADMINISTRADORES.contains(getTitular().getOrgaoUsuario().getSigla())) {
 			result.include("orgaosUsu", dao().listarOrgaosUsuarios());
@@ -698,7 +696,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	@Post("/app/pessoa/carga")
 	public Download carga(final UploadedFile arquivo, Long idOrgaoUsu) throws Exception {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_PESSOA);;
 		
 		InputStream inputStream = null;
 		try {
@@ -734,7 +732,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	@Post("/app/pessoa/usuarios/envioDeEmailPendente")
 	public void buscarUsuariosComEnvioDeEmailPendente(DpPessoaUsuarioDTO dados) {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_PESSOA);;
 		
 		DpPessoaDaoFiltro dpPessoa = new DpPessoaDaoFiltro();
 		
@@ -752,7 +750,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	public void enviaEmail(Integer paramoffset, Long idOrgaoUsu, String nome, String cpfPesquisa,
 			String idLotacaoPesquisa, String idUsuarioPesquisa, Integer paramTamanho) throws Exception {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_PESSOA);;
 		
 		result.include("request", getRequest());
 		List<CpOrgaoUsuario> list = new ArrayList<CpOrgaoUsuario>();
@@ -812,7 +810,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	@Post("app/pessoa/enviar")
 	public void enviar(Long idOrgaoUsu, String nome, String cpfPesquisa, String idLotacaoPesquisa, String idUsuarioPesquisa) throws Exception {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_PESSOA);;
 		
 		String[] senhaGerada = new String[1];
 
@@ -849,7 +847,7 @@ public class DpPessoaController extends SigaSelecionavelControllerSupport<DpPess
 	public Download exportarCsv(Long idOrgaoUsu, String nome, String cpfPesquisa, Long idCargoPesquisa,
 			Long idFuncaoPesquisa, Long idLotacaoPesquisa, String emailPesquisa, String identidadePesquisa) throws IOException {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_PESSOA);;
 
 		CpOrgaoUsuario ou = new CpOrgaoUsuario();
 

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/OrgaoUsuarioController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/OrgaoUsuarioController.java
@@ -33,6 +33,8 @@ import br.gov.jfrj.siga.model.dao.DaoFiltroSelecionavel;
 @Controller
 public class OrgaoUsuarioController extends SigaSelecionavelControllerSupport<CpOrgaoUsuario, DaoFiltroSelecionavel>{
 
+	private static final String VERIFICADOR_ACESSO = "GI:Módulo de Gestão de Identidade;CAD_ORGAO:Cadastrar Orgãos Usuário";
+
 	/**
 	 * @deprecated CDI eyes only
 	 */
@@ -55,9 +57,8 @@ public class OrgaoUsuarioController extends SigaSelecionavelControllerSupport<Cp
 	@Get("app/orgaoUsuario/listar")
 	public void lista(Integer paramoffset, Integer quantidadePagina, String nome) throws Exception {
 
-		final CpConfiguracaoBL businessLogic = Cp.getInstance().getComp().getConfiguracaoBL();
-		final boolean temConfiguracao = businessLogic.podeUtilizarServicoPorConfiguracao(getTitular(), getLotaTitular(), "SIGA;GI:Módulo de Gestão de Identidade;CAD_ORGAO_USUARIO: Cadastrar Orgãos Usuário");
-
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		if (paramoffset == null) {
 			paramoffset = 0;
 		}
@@ -77,7 +78,7 @@ public class OrgaoUsuarioController extends SigaSelecionavelControllerSupport<Cp
 		final String siglaOrgaoTitular = getTitular().getOrgaoUsuario().getSigla();
 		final boolean administrador = CpConfiguracaoBL.SIGLAS_ORGAOS_ADMINISTRADORES.contains(siglaOrgaoTitular);
 
-		result.include("usuarioPodeAlterar", administrador || temConfiguracao);
+		result.include("usuarioPodeAlterar", administrador);
 		result.include("orgaoUsuarioSiglaLogado", siglaOrgaoTitular);
 		result.include("administrador", CpConfiguracaoBL.SIGLA_ORGAO_ROOT.equalsIgnoreCase(siglaOrgaoTitular));
 
@@ -87,6 +88,9 @@ public class OrgaoUsuarioController extends SigaSelecionavelControllerSupport<Cp
 	
 	@Get("/app/orgaoUsuario/editar")
 	public void edita(final Long id){
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		if (id != null) {
 			CpContrato contrato = daoContrato(id);
 			CpOrgaoUsuario orgaoUsuario = daoOrgaoUsuario(id);
@@ -141,8 +145,8 @@ public class OrgaoUsuarioController extends SigaSelecionavelControllerSupport<Cp
 							 final String dtContrato,
 							 final Boolean isExternoOrgaoUsu
 	) throws Exception {
-
-		assertAcesso("GI:Módulo de Gestão de Identidade;CAD_ORGAO_USUARIO: Cadastrar Orgãos Usuário");
+		
+		assertAcesso(VERIFICADOR_ACESSO);
 
 		if (codOrgUsu == null) {
 			throw new AplicacaoException("Código Interno do Órgão não informado");
@@ -227,6 +231,9 @@ public class OrgaoUsuarioController extends SigaSelecionavelControllerSupport<Cp
 	@Transacional
 	@Post("/app/orgaoUsuario/ativar")
 	public void ativar(final Long id) throws Exception {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		CpOrgaoUsuario orgaoUsuario = dao().consultar(id, CpOrgaoUsuario.class, false);
 		CpOrgaoUsuario orgaoAnteriorAtivo = dao().consultarOrgaoUsuarioAtivoPorCodigoDeIntegracaoOuSigla(orgaoUsuario.getCodOrgaoUsu(), EMPTY);
 		if (orgaoAnteriorAtivo != null && !Objects.equals(orgaoUsuario.getId(), orgaoAnteriorAtivo.getId())) {
@@ -243,6 +250,9 @@ public class OrgaoUsuarioController extends SigaSelecionavelControllerSupport<Cp
 	@Transacional
 	@Post("/app/orgaoUsuario/desativar")
 	public void desativar(final Long codigoDeIntegracao) throws Exception {
+		
+		assertAcesso(VERIFICADOR_ACESSO);
+		
 		CpOrgaoUsuario orgaoUsuario = dao().consultarOrgaoUsuarioAtivoPorCodigoDeIntegracaoOuSigla(codigoDeIntegracao, EMPTY);
 		orgaoUsuario.setHisAtivo(0);
 		dao().gravar(orgaoUsuario);

--- a/siga/src/main/java/br/gov/jfrj/siga/vraptor/OrgaoUsuarioController.java
+++ b/siga/src/main/java/br/gov/jfrj/siga/vraptor/OrgaoUsuarioController.java
@@ -21,7 +21,7 @@ import br.com.caelum.vraptor.Post;
 import br.com.caelum.vraptor.Result;
 import br.gov.jfrj.siga.base.AplicacaoException;
 import br.gov.jfrj.siga.base.util.Texto;
-import br.gov.jfrj.siga.cp.bl.Cp;
+import br.gov.jfrj.siga.cp.CpServico;
 import br.gov.jfrj.siga.cp.bl.CpConfiguracaoBL;
 import br.gov.jfrj.siga.dp.CpContrato;
 import br.gov.jfrj.siga.dp.CpOrgaoUsuario;
@@ -32,8 +32,6 @@ import br.gov.jfrj.siga.model.dao.DaoFiltroSelecionavel;
 
 @Controller
 public class OrgaoUsuarioController extends SigaSelecionavelControllerSupport<CpOrgaoUsuario, DaoFiltroSelecionavel>{
-
-	private static final String VERIFICADOR_ACESSO = "GI:Módulo de Gestão de Identidade;CAD_ORGAO:Cadastrar Orgãos Usuário";
 
 	/**
 	 * @deprecated CDI eyes only
@@ -57,7 +55,7 @@ public class OrgaoUsuarioController extends SigaSelecionavelControllerSupport<Cp
 	@Get("app/orgaoUsuario/listar")
 	public void lista(Integer paramoffset, Integer quantidadePagina, String nome) throws Exception {
 
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_ORGAO_USUARIO);;
 		
 		if (paramoffset == null) {
 			paramoffset = 0;
@@ -89,7 +87,7 @@ public class OrgaoUsuarioController extends SigaSelecionavelControllerSupport<Cp
 	@Get("/app/orgaoUsuario/editar")
 	public void edita(final Long id){
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_ORGAO_USUARIO);;
 		
 		if (id != null) {
 			CpContrato contrato = daoContrato(id);
@@ -146,7 +144,7 @@ public class OrgaoUsuarioController extends SigaSelecionavelControllerSupport<Cp
 							 final Boolean isExternoOrgaoUsu
 	) throws Exception {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_ORGAO_USUARIO);;
 
 		if (codOrgUsu == null) {
 			throw new AplicacaoException("Código Interno do Órgão não informado");
@@ -232,7 +230,7 @@ public class OrgaoUsuarioController extends SigaSelecionavelControllerSupport<Cp
 	@Post("/app/orgaoUsuario/ativar")
 	public void ativar(final Long id) throws Exception {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_ORGAO_USUARIO);;
 		
 		CpOrgaoUsuario orgaoUsuario = dao().consultar(id, CpOrgaoUsuario.class, false);
 		CpOrgaoUsuario orgaoAnteriorAtivo = dao().consultarOrgaoUsuarioAtivoPorCodigoDeIntegracaoOuSigla(orgaoUsuario.getCodOrgaoUsu(), EMPTY);
@@ -251,7 +249,7 @@ public class OrgaoUsuarioController extends SigaSelecionavelControllerSupport<Cp
 	@Post("/app/orgaoUsuario/desativar")
 	public void desativar(final Long codigoDeIntegracao) throws Exception {
 		
-		assertAcesso(VERIFICADOR_ACESSO);
+		assertAcesso(CpServico.VERIFICADOR_ACESSO_CADASTRO_ORGAO_USUARIO);;
 		
 		CpOrgaoUsuario orgaoUsuario = dao().consultarOrgaoUsuarioAtivoPorCodigoDeIntegracaoOuSigla(codigoDeIntegracao, EMPTY);
 		orgaoUsuario.setHisAtivo(0);


### PR DESCRIPTION
Foi inserido o assertAcesso() nos módulos Órgão, Lotação, Pessoa, Função de Confiança, Cargo passando o parâmetro de cada Modulo de acordo com cada finalidade, conforme descrito no Banco.

Realizei testes com usuários nos grupos ROOT, ADMINISTRADORES e NÃO ADMINISTRADORES.

Para conhecimento: @michelrisucci-codata 