### PR TITLE
Correção bug em desentranhamento quando documento é o tipo capturado

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -5428,7 +5428,7 @@ public class ExBL extends CpBL {
 		if (mov != null && mov.getResp() != null && mov.getResp().getOrgaoUsuario() != null)
 			ou = mov.getResp().getOrgaoUsuario();
 
-		if (doc.isCapturado()) {
+		if (doc.isCapturado() && doc.getLotaCadastrante().getSigla().startsWith(CpConfiguracaoBL.SIGLA_ORGAO_PDS)) {
 			return StringUtils.LF;
 		}
 		return p.processarModelo(ou, attrs, params);


### PR DESCRIPTION
Como a linha criada tem a finalidade de evitar a quebra do documento capturado quando originado do PDS, só será utilizada se o documento tiver como lotação inicial PDS.