### PR TITLE
[BugFix] Adicionar timeout para gravação de documentos

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Nheengatu.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/itextpdf/Nheengatu.java
@@ -39,7 +39,7 @@ public class Nheengatu implements ConversorHtml {
 
 	private final HTML2PDFParser parser;
 	private static final Logger log = Logger.getLogger(Nheengatu.class);
-	private final int TIMEOUT_SECONDS = 5;
+	private final int TIMEOUT_SECONDS = 32;
 
 	public Nheengatu() {
 		parser = new HTML2PDFParser();
@@ -65,6 +65,7 @@ public class Nheengatu implements ConversorHtml {
 				log.debug("Erro na geração do PDF: " + e.getMessage());
 			}
 		});
+
         try {
             future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } catch (TimeoutException e) {
@@ -105,6 +106,6 @@ public class Nheengatu implements ConversorHtml {
 			} catch (InterruptedException ie) {
 				executor.shutdownNow();
 				Thread.currentThread().interrupt();
-				}
+			}
 		 }
 }

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -3505,13 +3505,7 @@ public class ExBL extends CpBL {
 		} catch (final Exception e) {
 			log.error("Não foi possível gravar o documento", e);
 			cancelarAlteracao();
-			Throwable t = e.getCause();
-			if (t != null && t instanceof InvocationTargetException)
-				t = t.getCause();
-			if (t != null && t instanceof AplicacaoException)
-				throw (AplicacaoException) t;
-			else
-				throw new RuntimeException("Erro na gravação", e);
+			throw new RuntimeException("Erro na gravação. " + e.getMessage(), e);
 		}
 		return doc;
 	}
@@ -5272,9 +5266,10 @@ public class ExBL extends CpBL {
 					try {
 						pdf = Documento.generatePdf(strHtml, conversor);
 					} catch (Exception e) {
-						throw new RuntimeException(
-								"Erro na geração do PDF. Por favor, verifique se existem recursos de formatação não suportados. Para eliminar toda a formatação do texto clique em voltar e depois, no editor, clique no botõo de 'Selecionar Tudo' e depois no botão de 'Remover Formatação'.",
-								e);
+						throw new AplicacaoException("Erro na geração do PDF. "
+								+ "Por favor, verifique se existem recursos de formatação não suportados. "
+								+ "Para eliminar toda a formatação do texto clique em voltar e depois, no editor, clique no botão de 'Selecionar Tudo' "
+								+ "e depois no botão de 'Remover Formatação'.");
 					}
 					doc.setConteudoBlobPdf(pdf);
 				}
@@ -5296,7 +5291,7 @@ public class ExBL extends CpBL {
 			if (gravar && transacao) {
 				cancelarAlteracao();
 			}
-			throw new RuntimeException("Erro na gravação", e);
+			throw new RuntimeException("Erro na gravação. " + e.getMessage(), e);
 		}
 	}
 

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -5267,7 +5267,7 @@ public class ExBL extends CpBL {
 						pdf = Documento.generatePdf(strHtml, conversor);
 					} catch (Exception e) {
 						throw new AplicacaoException("Erro na geração do PDF. "
-								+ "Por favor, verifique se existem recursos de formatação não suportados. "
+								+ "Por favor, evitar colar texto formato em outro editor, pois há recursos de formatação não suportados pelo PBdoc. "
 								+ "Para eliminar toda a formatação do texto clique em voltar e depois, no editor, clique no botão de 'Selecionar Tudo' "
 								+ "e depois no botão de 'Remover Formatação'.");
 					}

--- a/siga-ex/src/main/java/com/aryjr/nheengatu/pdf/PDFDocument.java
+++ b/siga-ex/src/main/java/com/aryjr/nheengatu/pdf/PDFDocument.java
@@ -211,7 +211,9 @@ public class PDFDocument extends com.aryjr.nheengatu.document.Document {
 			final PdfWriter writer = PdfWriter.getInstance(document, out);
 			writer.setPageEvent(new PDFPageBreak(writer, document,
 					headFirstPage, footFirstPage, head, foot));
-			document.open();
+			if (!document.isOpen()) {
+				document.open();
+			}
 			final MultiColumnText mct = new MultiColumnText();
 			// set up 3 even columns with 10pt space between
 			mct.addRegularColumns(document.left(), document.right(), 0f, 1);
@@ -221,7 +223,7 @@ public class PDFDocument extends com.aryjr.nheengatu.document.Document {
 
 			// Extracting the document content
 			extractVisibleComponents(body, document, mct, null, null);
-
+	
 			document.add(mct);
 			document.close();
 		} catch (final DocumentException de) {

--- a/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
+++ b/sigaex/src/main/java/br/gov/jfrj/siga/vraptor/ExDocumentoController.java
@@ -1974,7 +1974,7 @@ public class ExDocumentoController extends ExController {
 			}
 
 		} catch (final Exception e) {
-			throw new RuntimeException("Erro na gravação", e);
+			throw new AplicacaoException(e.getMessage());
 		}
 
 		if (param("ajax") != null && param("ajax").equals("true")) {


### PR DESCRIPTION
Esta PR adiciona um timeout para a geração da versão PDF de um documento. 
Em casos raros, a formatação do documento quebra a geração do PDF, fazendo com que a lib `itext` entre num loop.

Além disso, atualiza o tratamento da exceção para a gravação.