### PR TITLE
[Feature] Habilitar seleção de cargo na configuração de permissões

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExCompetenciaBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExCompetenciaBL.java
@@ -2360,7 +2360,7 @@ public class ExCompetenciaBL extends CpCompetenciaBL {
 				   || mob.doc().getLotaCadastrante().equivale(lotaTitular)				        
 				   || (mob.doc().getLotaSubscritor() != null && mob.doc().getLotaSubscritor().equivale(lotaTitular))
 			       || (mob.doc().getSubscritor() != null &&  mob.doc().getSubscritor().equivale(titular))) // subscritor é null para documentos externos
-		       && getConf().podePorConfiguracao(mob.doc().getExModelo(), CpTipoConfiguracao.TIPO_CONFIG_CRIAR_VIA);
+				&& getConf().podePorConfiguracao(titular, lotaTitular, mob.doc().getExFormaDocumento(), CpTipoConfiguracao.TIPO_CONFIG_CRIAR_VIA);
 	}
 
 	/**

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExDocumentoVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExDocumentoVO.java
@@ -725,8 +725,9 @@ public class ExDocumentoVO extends ExVO {
 			// documentos finalizados
 			if (mob.temAnexos()) {
 				vo.addAcao("script_key", "Assinar Anexos da Via",
-						"/app/expediente/mov", "assinarAnexos", true, null,
-						"assinandoAnexosGeral=true&sigla=" + getSigla(), null,
+						"/app/expediente/mov", "assinarAnexos", 
+						Ex.getInstance().getComp().podeAssinar(titular, lotaTitular, mob), 
+						null, "assinandoAnexosGeral=true&sigla=" + getSigla(), null,
 						null, null);
 			}
 		}

--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMobilVO.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/vo/ExMobilVO.java
@@ -372,8 +372,9 @@ public class ExMobilVO extends ExVO {
 
 			if (mob.temAnexos()) {
 				addAcao("script_key", "Assinar Anexos " + (mob.isVia() ? "da Via" : "do Volume"),
-						"/app/expediente/mov", "assinarAnexos", true, null,
-						"assinandoAnexosGeral=true&sigla=" + getSigla(), null,
+						"/app/expediente/mov", "assinarAnexos", 
+						Ex.getInstance().getComp().podeAssinar(titular, lotaTitular, mob), 
+						null, "assinandoAnexosGeral=true&sigla=" + getSigla(), null,
 						null, null);
 			}
 

--- a/siga/src/main/webapp/WEB-INF/page/dpCargo/busca.jsp
+++ b/siga/src/main/webapp/WEB-INF/page/dpCargo/busca.jsp
@@ -78,14 +78,14 @@ function sbmt(offset) {
 <br>
 <table  class="table table-sm table-striped">
 	<thead class="${thead_color}">
-		<th align="center">Sigla</th>
+		<th align="center">ID</th>
 		<th align="left">Nome</th>
 	</thead>
 	<siga:paginador maxItens="10" maxIndices="10" totalItens="${tamanho}"
 		itens="${itens}" var="item">
 		<tr class="${evenorodd}">
 			<td width="10%" align="center"><a
-				href="javascript: ${parteFuncao}.retorna_${propriedadeClean}('${item.id}','${item.sigla}','${item.descricao}');">${item.sigla}</a></td>
+				href="javascript: ${parteFuncao}.retorna_${propriedadeClean}('${item.id}','${item.sigla}','${item.descricao}');">${item.id}</a></td>
 			<td width="90%" align="left">${item.descricao}</td>
 		</tr>
 	</siga:paginador>


### PR DESCRIPTION
Esta PR modifica o pop-up de seleção de cargo para ser possível a seleção. 

Também modifica a aplicação de permissões para algumas ações:
- `Criar via` : não considerava o usuário/lotação, apenas o modelo;
- `Assinar anexos da via (ou volume)`: estava sempre habilitada. Agora está sendo vinculada à permissão de `podeAssinar`.